### PR TITLE
Kind declarations and Kind-level rewriting with -coc

### DIFF
--- a/parser/lexer.mll
+++ b/parser/lexer.mll
@@ -47,6 +47,7 @@ rule token = parse
   | ":="        { DEF           }
   | "_"         { UNDERSCORE ( get_loc lexbuf ) }
   | "Type"      { TYPE ( get_loc lexbuf )       }
+  | "Kind"      { KIND ( get_loc lexbuf )       }
   | "def"       { KW_DEF ( get_loc lexbuf )       }
   | "thm"       { KW_THM ( get_loc lexbuf )       }
   | "#NAME" space+ (mident as md)

--- a/parser/parser.mly
+++ b/parser/parser.mly
@@ -25,7 +25,7 @@
         | (l,x,ty)::tl -> PrePi(l,Some x,ty,mk_pi te tl)
 
     let rec preterm_loc = function
-        | PreType l | PreId (l,_) | PreQId (l,_) | PreLam  (l,_,_,_)
+        | PreType l | PreKind l | PreId (l,_) | PreQId (l,_) | PreLam  (l,_,_,_)
         | PrePi   (l,_,_,_) -> l
         | PreApp (f,_,_) -> preterm_loc f
 
@@ -66,6 +66,7 @@
 %token <Basic.loc> UNDERSCORE
 %token <Basic.loc*Basic.mident>NAME
 %token <Basic.loc> TYPE
+%token <Basic.loc> KIND
 %token <Basic.loc> KW_DEF
 %token <Basic.loc> KW_THM
 %token <Basic.loc*Basic.ident> ID
@@ -191,6 +192,8 @@ sterm           : QID
                 { $2 }
                 | TYPE
                 { PreType $1 }
+                | KIND
+                { PreKind $1 }
 
 term            : sterm+
                 { mk_pre_from_list $1 }

--- a/parser/preterm.ml
+++ b/parser/preterm.ml
@@ -3,6 +3,7 @@ open Format
 
 type preterm =
   | PreType of loc
+  | PreKind of loc
   | PreId   of loc * ident
   | PreQId  of loc * name
   | PreApp  of preterm * preterm * preterm list
@@ -12,6 +13,7 @@ type preterm =
 let rec pp_preterm fmt preterm =
   match preterm with
   | PreType _        -> fprintf fmt "Type"
+  | PreKind _        -> fprintf fmt "Kind"
   | PreId (_,v)      -> pp_ident fmt v
   | PreQId (_,cst)   -> fprintf fmt "%a" pp_name cst
   | PreApp (f,a,lst) -> pp_list " " pp_preterm_wp  fmt (f::a::lst)
@@ -24,8 +26,8 @@ let rec pp_preterm fmt preterm =
 
 and pp_preterm_wp fmt preterm =
   match preterm with
-  | PreType _ | PreId _ | PreQId _ as t  -> pp_preterm fmt t
-  | t                                    -> fprintf fmt "(%a)" pp_preterm t
+  | PreType _ | PreKind _ | PreId _ | PreQId _ as t  -> pp_preterm fmt t
+  | t                                                -> fprintf fmt "(%a)" pp_preterm t
 
 type prepattern =
   | PCondition  of preterm

--- a/parser/preterm.mli
+++ b/parser/preterm.mli
@@ -7,6 +7,7 @@ open Format
 
 type preterm =
   | PreType of loc
+  | PreKind of loc
   | PreId   of loc * ident
   | PreQId  of loc * name
   | PreApp  of preterm * preterm * preterm list

--- a/parser/scoping.ml
+++ b/parser/scoping.ml
@@ -17,6 +17,7 @@ let empty = mk_ident ""
 let rec t_of_pt (ctx:ident list) (pte:preterm) : term =
   match pte with
     | PreType l    -> mk_Type l
+    | PreKind l    -> mk_Kind
     | PreId (l,id) ->
         begin
           match get_db_index ctx id with

--- a/parser/tokens.ml
+++ b/parser/tokens.ml
@@ -3,6 +3,7 @@ open Basic
 type token =
   | UNDERSCORE  of loc
   | TYPE        of loc
+  | KIND        of loc
   | KW_DEF      of loc
   | KW_THM      of loc
   | RIGHTSQU

--- a/parser/tokens.mli
+++ b/parser/tokens.mli
@@ -3,6 +3,7 @@ open Basic
 type token =
   | UNDERSCORE  of loc
   | TYPE        of loc
+  | KIND        of loc
   | KW_DEF      of loc
   | KW_THM      of loc
   | RIGHTSQU


### PR DESCRIPTION
If my understanding of the Calculus of Constructions Modulo (chapter 2.8 in Ronan's thesis) is correct, Dedukti should accept declarations and rewrite rules in Kind when -coc is used.

For example, the following file should be accepted:
```
#NAME test.
a : Kind.

def b : Kind.
[] b --> Type.

def c : Kind := Type.

def d := Type.

thm e : Kind := Type.
```

This commit implements this feature.