### PR TITLE
Add the name of the rule for the dtree type

### DIFF
--- a/kernel/dtree.mli
+++ b/kernel/dtree.mli
@@ -41,7 +41,7 @@ val pp_matching_problem : Format.formatter -> matching_problem -> unit
 (** Type of decision trees *)
 type dtree =
   | Switch  of int * (case*dtree) list * dtree option (** Switch [i] [(case_0,tree_0) ; ... ; (case_n, tree_n)] [tree_opt] test if the [i] arg of a pattern can be match with one of the case of the list. if it does then look at the corresponding tree, otherwise, look at the default tree *)
-  | Test    of matching_problem * constr list * Term.term * dtree option (** Test [pb] [cstrs] [te] [tree_opt] are the leaves of the tree. Check that each problem can be solves and such that constraints are satisfied. If it does then return a local context for the term [te]. *)
+  | Test    of rule_name * matching_problem * constr list * Term.term * dtree option (** Test [pb] [cstrs] [te] [tree_opt] are the leaves of the tree. Check that each problem can be solves and such that constraints are satisfied. If it does then return a local context for the term [te]. *)
 
 val pp_dtree : Format.formatter -> dtree -> unit
 

--- a/kernel/dtree.mli
+++ b/kernel/dtree.mli
@@ -41,7 +41,8 @@ val pp_matching_problem : Format.formatter -> matching_problem -> unit
 (** Type of decision trees *)
 type dtree =
   | Switch  of int * (case*dtree) list * dtree option (** Switch [i] [(case_0,tree_0) ; ... ; (case_n, tree_n)] [tree_opt] test if the [i] arg of a pattern can be match with one of the case of the list. if it does then look at the corresponding tree, otherwise, look at the default tree *)
-  | Test    of rule_name * matching_problem * constr list * Term.term * dtree option (** Test [pb] [cstrs] [te] [tree_opt] are the leaves of the tree. Check that each problem can be solves and such that constraints are satisfied. If it does then return a local context for the term [te]. *)
+  | Test    of rule_name * matching_problem * constr list * Term.term * dtree option
+  (** Test [name] [pb] [cstrs] [te] [tree_opt] are the leaves of the tree. Check that each problem can be solves and such that constraints are satisfied. If it does then return a local context for the term [te]. *)
 
 val pp_dtree : Format.formatter -> dtree -> unit
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -207,7 +207,7 @@ let gamma_rw (sg:Signature.t)
          This is the reason why s is added at the end. *)
          | None -> None
        end
-    | Test (Syntactic ord, eqs, right, def) ->
+    | Test (_,Syntactic ord, eqs, right, def) ->
        begin
          match get_context_syn sg forcing stack ord with
          | None -> bind_opt (rw stack) def
@@ -215,7 +215,7 @@ let gamma_rw (sg:Signature.t)
             if test sg convertible ctx eqs then Some (ctx, right)
             else bind_opt (rw stack) def
        end
-    | Test (MillerPattern lst, eqs, right, def) ->
+    | Test (_,MillerPattern lst, eqs, right, def) ->
        begin
          match get_context_mp sg forcing stack lst with
          | None -> bind_opt (rw stack) def


### PR DESCRIPTION
Add names in the dtree type so that it is easier to check which rule is applied. This is the first step toward a command to print rewriting steps while checking a term.