### PR TITLE
Allows identifiers to start with a `?` or a `!` and solved issue #40

### DIFF
--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -35,7 +35,7 @@ let mk_entry md e =
         let get_infos p =
           match p with
           | Pattern(l,cst,_) -> (l,cst)
-          | _                -> (dloc,mk_name (mk_mident "") qmark)
+          | _                -> (dloc,mk_name (mk_mident "") dmark)
         in
         let r = List.hd rs in (* cannot fail. *)
         let (l,cst) = get_infos r.pat in

--- a/kernel/basic.ml
+++ b/kernel/basic.ml
@@ -47,8 +47,6 @@ let mk_mident md =
   let base = Filename.basename md in
   try Filename.chop_extension base with _ -> base
 
-let qmark       = mk_ident "?"
-
 let dmark       = mk_ident "$"
 
 (** {2 Lists with Length} *)

--- a/kernel/basic.mli
+++ b/kernel/basic.mli
@@ -52,10 +52,8 @@ val name_eq : name -> name -> bool
 val pp_name : Format.formatter -> name -> unit
 
 (** qmark is a special identifier for unification variables *)
-val qmark : ident
-
-(** dmark is a meaningless identifier *)
 val dmark : ident
+
 (** The kernel may introduce such identifiers when creating new de Bruijn indices *)
 
 (** {2 Lists with Length} *)

--- a/kernel/matching.ml
+++ b/kernel/matching.ml
@@ -26,6 +26,6 @@ let update_dbs (depth:int) (dbs:int LList.t) (te:term) : term =
 let solve (n:int) (k_lst:int LList.t) (te:term) : term =
   let rec add_lam te = function
     | [] -> te
-    | _::lst -> add_lam (mk_Lam dloc qmark None te) lst
+    | _::lst -> add_lam (mk_Lam dloc dmark None te) lst
   in
   add_lam (update_dbs n k_lst te) (LList.lst k_lst)

--- a/kernel/pp.ml
+++ b/kernel/pp.ml
@@ -94,7 +94,7 @@ let rec print_term out = function
   | Lam (_,x,None,f)   -> Format.fprintf out "@[%a =>@ @[%a@]@]" print_ident x print_term f
   | Lam (_,x,Some a,f) ->
       Format.fprintf out "@[%a:@,%a =>@ @[%a@]@]" print_ident x print_term_wp a print_term f
-  | Pi  (_,x,a,b) when ident_eq x qmark  ->
+  | Pi  (_,x,a,b) when ident_eq x dmark  ->
       (* arrow, no pi *)
       Format.fprintf out "@[%a ->@ @[%a@]@]" print_term_wp a print_term b
   | Pi  (_,x,a,b)      ->

--- a/kernel/pp.ml
+++ b/kernel/pp.ml
@@ -29,8 +29,8 @@ let print_const out cst =
 
 (* Idents generated from underscores by the parser start with a question mark.
    We have sometimes to avoid to print them because they are not valid tokens. *)
-let is_dummy_ident i = (string_of_ident i).[0] = '?'
-let is_regular_ident i = (string_of_ident i).[0] <> '?'
+let is_dummy_ident i = (string_of_ident i).[0] = '$'
+let is_regular_ident i = (string_of_ident i).[0] <> '$'
 
 let print_db out (x,n) =
   if !print_db_enabled then Format.fprintf out "%a[%i]" print_ident x n

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -40,7 +40,7 @@ let mk_DB l x n         = DB (l,x,n)
 let mk_Const l n        = Const (l,n)
 let mk_Lam l x a b      = Lam (l,x,a,b)
 let mk_Pi l x a b       = Pi (l,x,a,b)
-let mk_Arrow l a b      = Pi (l,qmark,a,b)
+let mk_Arrow l a b      = Pi (l,dmark,a,b)
 
 let mk_App f a1 args =
   match f with

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -242,10 +242,10 @@ let pc_add (delta:partial_context) (n:int) (l:loc) (id:ident) (ty0:typ) : partia
 let pc_to_context (delta:partial_context) : typed_context = LList.lst delta.pctx
 
 let pc_to_context_wp (delta:partial_context) : typed_context =
-  let dummy = mk_DB dloc qmark 0 in
+  let dummy = mk_DB dloc dmark 0 in
   let rec aux lst n =
     if n <= 0 then lst
-    else aux ((dloc,qmark,dummy)::lst) (n-1)
+    else aux ((dloc,dmark,dummy)::lst) (n-1)
   in
   aux (LList.lst delta.pctx) delta.padding
 

--- a/parser/lexer.mll
+++ b/parser/lexer.mll
@@ -20,7 +20,7 @@
 
 let space   = [' ' '\t' '\r']
 let mident = ['a'-'z' 'A'-'Z' '0'-'9' '_']+
-let ident   = ['a'-'z' 'A'-'Z' '0'-'9' '_']['a'-'z' 'A'-'Z' '0'-'9' '_' '!' '?' '\'' ]*
+let ident   = ['a'-'z' 'A'-'Z' '0'-'9' '_' '!' '?']['a'-'z' 'A'-'Z' '0'-'9' '_' '!' '?' '\'' ]*
 let capital = ['A'-'Z']+
 
 rule token = parse

--- a/parser/menhir_parser.mly
+++ b/parser/menhir_parser.mly
@@ -174,6 +174,10 @@ top_pattern:
   | ID  pattern_wp* { (fst $1,None,snd $1,$2) }
   | QID pattern_wp* { let (l,md,id)=$1 in (l,Some md,id,$2) }
 
+%inline pid:
+  | UNDERSCORE { ($1, mk_ident "_") }
+  | ID { $1 }
+
 pattern_wp:
   | ID                       { PPattern (fst $1,None,snd $1,[]) }
   | QID                      { let (l,md,id)=$1 in PPattern (l,Some md,id,[]) }
@@ -184,12 +188,12 @@ pattern_wp:
 pattern:
   | ID  pattern_wp+          { PPattern (fst $1,None,snd $1,$2) }
   | QID pattern_wp+          { let (l,md,id)=$1 in PPattern (l,Some md,id,$2) }
-  | ID FATARROW pattern      { PLambda (fst $1,snd $1,$3) }
+  | ID  FATARROW pattern     { PLambda (fst $1,snd $1,$3) }
   | pattern_wp               { $1 }
 
 sterm:
   | QID                      { let (l,md,id)=$1 in PreQId(l,mk_name md id) }
-  | ID                       { PreId (fst $1,snd $1) }
+  | pid                      { PreId (fst $1,snd $1) }
   | LEFTPAR term RIGHTPAR    { $2 }
   | TYPE                     { PreType $1 }
 
@@ -200,14 +204,14 @@ aterm:
 term:
   | t=aterm
       { t }
-  | ID COLON aterm ARROW term
+  | pid COLON aterm ARROW term
       { PrePi (fst $1,Some (snd $1), $3, $5) }
   | LEFTPAR ID COLON aterm RIGHTPAR ARROW term
       { PrePi (fst $2,Some (snd $2), $4 ,$7) }
   | term ARROW term
       { PrePi (Lexer.loc_of_pos $startpos,None,$1,$3) }
-  | ID FATARROW term
+  | pid FATARROW term
       {PreLam (fst $1, snd $1, None, $3)}
-  | ID COLON aterm FATARROW term
+  | pid COLON aterm FATARROW term
       {PreLam (fst $1, snd $1, Some $3, $5)}
 %%


### PR DESCRIPTION
Try to solve issue #40 . However, I did not extend the grammar for lambdas in patterns. Indeed, on the following example there would be a conflict :
 ```
#NAME subst.

A : Type.

def T : (A -> A) -> Type.

[] T (_ => _) --> A.

#EVAL T (x => x). (; What should be the answer here ? ;)
```
