### PR TITLE
Convertibility witness

### DIFF
--- a/kernel/env.ml
+++ b/kernel/env.ml
@@ -133,3 +133,13 @@ let are_convertible ?ctx:(ctx=[]) te1 te2 =
   with
   | SignatureError e -> Err (EnvErrorSignature e)
   | TypingError    e -> Err (EnvErrorType e)
+
+let are_convertible_witness ?ctx:(ctx=[]) te1 te2 =
+  try
+    ignore(Typing.infer !sg ctx te1);
+    ignore(Typing.infer !sg ctx te2);
+    let b = Reduction.are_convertible_witness !sg te1 te2 in
+    OK b
+  with
+  | SignatureError e -> Err (EnvErrorSignature e)
+  | TypingError    e -> Err (EnvErrorType e)

--- a/kernel/env.mli
+++ b/kernel/env.mli
@@ -58,4 +58,6 @@ val reduction : ?ctx:typed_context -> ?red:(Reduction.red_cfg) -> term -> (term,
 
 val are_convertible : ?ctx:typed_context -> term -> term -> (bool,env_error) error
 
+val are_convertible_witness : ?ctx:typed_context -> term -> term -> ((unit, term * term) error,env_error) error
+
 val unsafe_reduction : ?red:(Reduction.red_cfg) -> term -> term

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -24,3 +24,5 @@ val reduction : red_cfg -> Signature.t -> term -> term
 val are_convertible : Signature.t -> term -> term -> bool
 (** [are_convertible sg t1 t2] check if [t1] and [t2] are convertible using the
     signature [sg]. *)
+
+val are_convertible_witness : Signature.t -> term -> term -> (unit, term * term) Basic.error


### PR DESCRIPTION
This is mostly an API enhancement. This PR introduces a bit of code duplication so your remarks to have a cleaner code are welcome ;)

Using the API kernel, having a witness when two terms are not convertible is very handy. This avoids going through the term looking for the witness.