### PR TITLE
Renaming DB variables before ConvertibilityError

### DIFF
--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -64,3 +64,20 @@ let rec term_eq t1 t2 =
 type untyped_context = ( loc * ident ) list
 
 type typed_context = ( loc * ident * term ) list
+
+let rec get_name_from_typed_ctxt ctxt i =
+  try let (_,v,_) = List.nth ctxt i in Some v
+  with Failure _ -> None
+
+let rename_vars_with_typed_context ctxt t =
+  let rec aux d = function
+    | DB  (l,v,n)        ->
+      let v' = (match get_name_from_typed_ctxt ctxt (n - d) with Some v -> v | None -> v) in
+      mk_DB l v' n
+    | App (f,a,args)     ->
+      mk_App (aux d f) (aux d a) (List.map (aux d) args)
+    | Lam (l,x,None,f)   -> mk_Lam l x None (aux (d+1) f)
+    | Lam (l,x,Some a,f) -> mk_Lam l x (Some (aux d a)) (aux (d+1) f)
+    | Pi  (l,x,a,b)      -> mk_Pi l x (aux d a) (aux (d+1) b)
+    | te -> te in
+  aux 0 t

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -37,3 +37,5 @@ type untyped_context = (loc * ident) list
 
 (** type checking rules implies to give a type to the variables of the context *)
 type typed_context = ( loc * ident * term ) list
+
+val rename_vars_with_typed_context : typed_context -> term -> term

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -75,6 +75,7 @@ let rec infer sg (ctx:typed_context) : term -> typ = function
   | Lam  (l,x,None,b) -> raise (TypingError (DomainFreeLambda l))
 
 and check sg (ctx:typed_context) (te:term) (ty_exp:typ) : unit =
+  debug 3 "Checking: %a : %a" pp_term te pp_term ty_exp;
   match te with
   | Lam (l,x,None,b) ->
     begin
@@ -95,7 +96,9 @@ and check sg (ctx:typed_context) (te:term) (ty_exp:typ) : unit =
   | _ ->
     let ty_inf = infer sg ctx te in
     if Reduction.are_convertible sg ty_inf ty_exp then ()
-    else raise (TypingError (ConvertibilityError (te,ctx,ty_exp,ty_inf)))
+    else
+      let ty_exp' = rename_vars_with_typed_context ctx ty_exp in
+      raise (TypingError (ConvertibilityError (te,ctx,ty_exp',ty_inf)))
 
 and check_app sg (ctx:typed_context) (f,ty_f:term*typ) (arg:term) : term*typ =
   match whnf sg ty_f with


### PR DESCRIPTION
This is related to Issue #56 