### PR TITLE
Remove types in rule contexts completely.

### DIFF
--- a/parser/menhir_parser.mly
+++ b/parser/menhir_parser.mly
@@ -73,7 +73,6 @@ let mk_config loc id1 id2_opt =
 %start line
 %type <Basic.mident -> Entry.entry> line
 %type <Preterm.prule> rule
-%type <Preterm.pdecl> decl
 %type <Basic.loc*Basic.ident*Preterm.preterm> param
 %type <Preterm.pdecl list> context
 %type <Basic.loc*Basic.mident option*Basic.ident*Preterm.prepattern list> top_pattern
@@ -165,13 +164,9 @@ rule:
         let (_,m,v) = $2 in
         ( l , Some (Some m,v), $5 , md_opt, id , args , $9)}
 
-decl:
-  | ID COLON term { debug 1 "Ignoring type declaration in rule context."; $1 }
-  | ID            { $1 }
-
 context:
-  | /* empty */                          { [] }
-  | separated_nonempty_list(COMMA, decl) { $1 }
+  | /* empty */                        { [] }
+  | separated_nonempty_list(COMMA, ID) { $1 }
 
 top_pattern:
   | ID  pattern_wp* { (fst $1,None,snd $1,$2) }

--- a/parser/menhir_parser.mly
+++ b/parser/menhir_parser.mly
@@ -165,8 +165,7 @@ rule:
         ( l , Some (Some m,v), $5 , md_opt, id , args , $9)}
 
 context:
-  | /* empty */                        { [] }
-  | separated_nonempty_list(COMMA, ID) { $1 }
+  | l=separated_list(COMMA, ID) { l }
 
 top_pattern:
   | ID  pattern_wp* { (fst $1,None,snd $1,$2) }


### PR DESCRIPTION
Following a discussion with @fblanqui, it would be best to completely remove this piece of syntax. It is already ignored in the internals, and makes absolutely no sense. Furthermore, it should not break generators as far as I know.