### PR TITLE
[WIP] Add a command to trace the rewrite rules

### DIFF
--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -82,7 +82,8 @@ let mk_entry md e =
       | Err e -> Errors.fail_signature_error e
     end
   | Print(_,s) -> Format.printf "%s@." s
-  | Name(_,n) ->
+  | Trace(_)   -> Format.printf "%a@." Reduction.pp_trace (Reduction.get_trace ())
+  | Name(_,n)  ->
     if not (mident_eq n md)
     then warn "Invalid #NAME directive ignored.\n%!"
   | Require(lc,md) ->

--- a/commands/dkdep.ml
+++ b/commands/dkdep.ml
@@ -87,6 +87,7 @@ let handle_entry e =
   | Check(_,_,_,HasType(te,ty)) -> mk_term te; mk_term ty
   | DTree(_,_,_)                -> ()
   | Print(_,_)                  -> ()
+  | Trace(_)                    -> ()
   | Name(_,_)                   -> ()
   | Require(_,md)               -> add_dep md
 

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -74,6 +74,7 @@ let handle_entry e =
       | Err e -> Errors.fail_signature_error e
     end
   | Print(_,s)   -> Format.printf "%s@." s
+  | Trace(_)   -> Format.printf "%a@." Reduction.pp_trace (Reduction.get_trace ())
   | Name(_,_)    -> Format.printf "\"#NAME\" directive ignored.@."
   | Require(_,_) -> Format.printf "\"#REQUIRE\" directive ignored.@."
 

--- a/kernel/entry.ml
+++ b/kernel/entry.ml
@@ -10,15 +10,16 @@ type test =
   | HasType of term * term
 
 type entry =
-  | Decl  of loc * ident * Signature.staticity * term
-  | Def   of loc * ident * is_opaque * term option * term
-  | Rules of Rule.untyped_rule list
-  | Eval  of loc * Reduction.red_cfg * term
-  | Check of loc * is_assertion * should_fail * test
-  | Infer of loc * Reduction.red_cfg * term
-  | Print of loc * string
-  | DTree of loc * mident option * ident
-  | Name  of loc * mident
+  | Decl    of loc * ident * Signature.staticity * term
+  | Def     of loc * ident * is_opaque * term option * term
+  | Rules   of Rule.untyped_rule list
+  | Eval    of loc * Reduction.red_cfg * term
+  | Check   of loc * is_assertion * should_fail * test
+  | Infer   of loc * Reduction.red_cfg * term
+  | Print   of loc * string
+  | DTree   of loc * mident option * ident
+  | Name    of loc * mident
+  | Trace   of loc
   | Require of loc * mident
 
 let pp_entry fmt e =
@@ -63,5 +64,6 @@ let pp_entry fmt e =
     fprintf fmt "#PRINT %S.@." str
   | Name(_,_)               ->
     ()
+  | Trace _                 -> fprintf fmt "#TRACE"
   | Require(_,m)            ->
     fprintf fmt "#REQUIRE %a.@." pp_mident m

--- a/kernel/entry.mli
+++ b/kernel/entry.mli
@@ -33,6 +33,8 @@ type entry =
   | DTree of loc * mident option * ident
   (** Obsolete #NAME command. *)
   | Name  of loc * mident
+  (** Trace command. *)
+  | Trace  of loc
   (** Require command. *)
   | Require  of loc * mident
 

--- a/kernel/pp.ml
+++ b/kernel/pp.ml
@@ -225,6 +225,7 @@ let print_entry fmt e =
     end
   | Print(_, str)           ->
     fprintf fmt "#PRINT %S.@." str
+  | Trace(_)   -> printf "#TRACE."
   | Name(_,_)               ->
     ()
   | Require(_, md) ->

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -43,11 +43,6 @@ let init_tracer b =
   is_left := b;
   tracer := empty_trace
 
-let finalize_tracer () =
-  tracer := {left  = List.rev !tracer.left;
-             right = List.rev !tracer.right;
-            }
-
 let add_step rw =
   if !is_left then
     tracer := {!tracer with left = rw:: !tracer.left}
@@ -334,7 +329,7 @@ and snf sg (t:term) : term =
 
 and are_convertible_lst sg : (term*term) list -> bool =
   function
-  | [] -> finalize_tracer (); true
+  | [] -> true
   | (t1,t2)::lst ->
     begin
       match (
@@ -352,7 +347,7 @@ and are_convertible_lst sg : (term*term) list -> bool =
           | Pi (_,_,a,b), Pi (_,_,a',b') -> Some ((a,a')::(b,b')::lst)
           | t1, t2 -> None
       ) with
-      | None -> finalize_tracer (); false
+      | None -> false
       | Some lst2 -> are_convertible_lst sg lst2
     end
 
@@ -457,5 +452,4 @@ let reduction strat sg te =
     | _ -> reduction strat.strategy sg te
   in
   select default_cfg.select default_cfg.beta;
-  finalize_tracer ();
   te'

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -6,13 +6,25 @@ open Term
 type red_strategy = Hnf | Snf | Whnf
 
 type red_cfg = {
-  select : (Rule.rule_name -> bool) option;
+  select   : (Rule.rule_name -> bool) option;
   nb_steps : int option; (* [Some 0] for no evaluation, [None] for no bound *)
   strategy : red_strategy;
-  beta : bool
+  beta     : bool
 }
 
 val pp_red_cfg : red_cfg printer
+
+type step = Rule.rule_name option (* None for Beta *)
+
+type trace =
+  {
+    left  : step list;
+    right : step list
+  }
+
+val get_trace : unit -> trace
+
+val pp_trace : trace printer
 
 (** [beta] flag enables/disables beta reductions.
     [select] = [Some f] restreins rules according to the given filter on names.
@@ -20,10 +32,11 @@ val pp_red_cfg : red_cfg printer
 
 val default_cfg : red_cfg
 (** default configuration where:
-    [select] = [None] ;
+    [select]   = [None] ;
     [nb_steps] = [None] ;
-    [strategy] = [Snf] ;
-    [beta] = [true] ;
+    [strategy] = [Snf]  ;
+    [beta]     = [true] ;
+    [trace]    = [false ;
 *)
 
 val reduction : red_cfg -> Signature.t -> term -> term

--- a/parser/lexer.mll
+++ b/parser/lexer.mll
@@ -54,6 +54,7 @@ rule token = parse
   | "#ASSERT"   { ASSERT     ( get_loc lexbuf ) }
   | "#ASSERTNOT"{ ASSERTNOT  ( get_loc lexbuf ) }
   | "#PRINT"    { PRINT      ( get_loc lexbuf ) }
+  | "#TRACE"    { TRACE      ( get_loc lexbuf ) }
   | "#GDT"      { GDT        ( get_loc lexbuf ) }
   | mident as md '.' (ident as id)
   { QID ( get_loc lexbuf , mk_mident md , mk_ident id ) }

--- a/parser/menhir_parser.mly
+++ b/parser/menhir_parser.mly
@@ -59,6 +59,7 @@ let mk_config loc id1 id2_opt =
 %token <Basic.loc> ASSERT
 %token <Basic.loc> ASSERTNOT
 %token <Basic.loc> PRINT
+%token <Basic.loc> TRACE
 %token <Basic.loc> GDT
 %token <Basic.loc> UNDERSCORE
 %token <Basic.loc*Basic.mident> NAME
@@ -136,6 +137,7 @@ line:
       {fun md -> Check($1, true , true , Convert(scope_term md [] t1, scope_term md [] t2))}
 
   | PRINT STRING DOT {fun _ -> Print($1, $2)}
+  | TRACE DOT        {fun _ -> Trace($1)}
   | GDT   ID     DOT {fun _ -> DTree($1, None, snd $2)}
   | GDT   QID    DOT {fun _ -> let (_,m,v) = $2 in DTree($1, Some m, v)}
   | n=NAME       DOT {fun _ -> Name(fst n, snd n)}

--- a/parser/tokens.ml
+++ b/parser/tokens.ml
@@ -32,6 +32,7 @@ type token =
   | CHECKNOT   of loc
   | ASSERTNOT  of loc
   | PRINT      of loc
+  | TRACE      of loc
   | GDT        of loc
   | STRING     of string
   | INT        of int


### PR DESCRIPTION
The purpose of this PR is to have an interface to see a trace of the rewrite steps made by the rewrite engine. For the moment, this PR adds a new command `#TRACE` that can be used after a command to see the rules used for the last command. However, this PR aims also to give an API to use the *tracer* abilities.

TODO :
- [ ] Give the position of the rewrite step (is it possible without decreasing the performances?)
- [ ] Given a term and a trace, unfold the steps
