### PR TITLE
Move arity checking in typing

### DIFF
--- a/kernel/basic.ml
+++ b/kernel/basic.ml
@@ -127,7 +127,7 @@ let map_error_list (f:'a -> ('b,'c) error) (lst:'a list) : ('b list,'c) error =
 (** {2 Debugging} *)
 
 module Debug = struct
-  
+
   type flag = int
   let d_warn         : flag = 0
   let d_notice       : flag = 1
@@ -160,9 +160,9 @@ module Debug = struct
 
   let  enable_flag f = active.(f) <- true
   let disable_flag f = active.(f) <- false
-      
+
   exception DebugFlagNotRecognized of char
-      
+
   let set_debug_mode =
     String.iter (function
         | 'q' -> disable_flag d_warn
@@ -175,15 +175,15 @@ module Debug = struct
         | 'm' -> enable_flag  d_matching
         | c -> raise (DebugFlagNotRecognized c)
       )
-      
+
   let do_debug fmt =
     Format.(kfprintf (fun _ -> pp_print_newline err_formatter ()) err_formatter fmt)
-      
+
   let ignore_debug fmt =
     Format.(ifprintf err_formatter) fmt
-      
+
   let debug f =
-    if active.(f) 
+    if active.(f)
     then
       match headers.(f) with
       | "" -> do_debug
@@ -194,6 +194,17 @@ module Debug = struct
   let debug_eval f clos = if active.(f) then clos ()
 
 end
+
+(** {2 Misc modules} *)
+
+module IntHashtbl =
+  Hashtbl.Make(struct
+    type t = int
+    let equal i j = i=j
+    let hash i = i land max_int
+  end
+  )
+
 
 (** {2 Misc functions} *)
 

--- a/kernel/basic.mli
+++ b/kernel/basic.mli
@@ -101,7 +101,7 @@ val map_error_list : ('a -> ('b,'c) error) -> 'a list -> ('b list,'c) error
 (** {2 Debug} *)
 
 module Debug : sig
-  
+
   type flag
   val d_warn         : flag (** Warnings *)
   val d_notice       : flag (** Notices *)
@@ -115,7 +115,7 @@ module Debug : sig
   val  enable_flag : flag -> unit (** Activates given flag's debugging *)
   val disable_flag : flag -> unit (** Deactivates given flag's debugging *)
 
-  (** Sets multiple debugging flags from a string: 
+  (** Sets multiple debugging flags from a string:
       q : disables d_Warn
       n : enables  d_Notice
       o : enables  d_Module
@@ -130,7 +130,7 @@ module Debug : sig
   (** [debug f] prints information on the standard error channel
       if the given flag [f] is currently active. *)
   val debug : flag -> ('a, Format.formatter, unit, unit) format4 -> 'a
-    
+
   (** [debug_eval f (fun () -> body] evaluates [body]
       if the given flag [f] is currently active. *)
   val debug_eval : flag -> (unit -> unit) -> unit
@@ -138,6 +138,8 @@ end
 
 
 (** {2 Misc} *)
+
+module IntHashtbl : Hashtbl.S with type key = int
 
 val fold_map : ('b->'a-> ('c*'b)) -> 'b -> 'a list -> ('c list*'b)
 

--- a/kernel/errors.ml
+++ b/kernel/errors.ml
@@ -92,6 +92,11 @@ let fail_typing_error err =
     fail l "Assertion error. '%a' is of type '%a'"
       pp_term t1 pp_term t2
   | NotImplementedFeature l -> fail l "Feature not implemented."
+  | NonLinearNonEqArguments(lc,arg) ->
+    fail lc "For each occurence of the free variable %a, the symbol should be applied to the same number of arguments" pp_ident arg
+  | NotEnoughArguments (lc,id,n,nb_args,exp_nb_args) ->
+    fail lc "The variable '%a' is applied to %i argument(s) (expected: at least %i)."
+      pp_ident id nb_args exp_nb_args
 
 let fail_dtree_error err =
   let open Dtree in
@@ -122,15 +127,10 @@ let fail_rule_error err =
       pp_ident x pp_pattern pat
   | AVariableIsNotAPattern (lc,id) ->
     fail lc "A variable is not a valid pattern."
-  | NotEnoughArguments (lc,id,n,nb_args,exp_nb_args) ->
-    fail lc "The variable '%a' is applied to %i argument(s) (expected: at least %i)."
-      pp_ident id nb_args exp_nb_args
   | NonLinearRule r ->
     fail (Rule.get_loc_pat r.pat) "Non left-linear rewrite rule:\n%a.\n\
                                Maybe you forgot to pass the -nl option."
       pp_untyped_rule r
-  | NonLinearNonEqArguments(lc,arg) ->
-    fail lc "For each occurence of the free variable %a, the symbol should be applied to the same number of arguments" pp_ident arg
 
 let pp_cerr out err =
   let open Confluence in

--- a/kernel/rule.ml
+++ b/kernel/rule.ml
@@ -177,14 +177,6 @@ let rec all_distinct = function
   | [] -> true
   | hd::tl -> if List.mem hd tl then false else all_distinct tl
 
-module IntHashtbl =
-  Hashtbl.Make(struct
-    type t = int
-    let equal i j = i=j
-    let hash i = i land max_int
-  end
-  )
-
 (* TODO : cut this function in smaller ones *)
 (** [check_patterns size pats] checks that the given pattern is a well formed
 Miller pattern in a context of size [size] and linearizes it.

--- a/kernel/rule.ml
+++ b/kernel/rule.ml
@@ -68,9 +68,7 @@ type rule_error =
   (* FIXME : this exception seems never to be raised *)
   | AVariableIsNotAPattern         of loc * ident
   | NonLinearRule                  of untyped_rule
-  | NotEnoughArguments             of loc * ident * int * int * int
-  | NonLinearNonEqArguments        of loc * ident
-  (* FIXME: the reason for this exception should be formalized on paper ! *)
+
 
 exception RuleExn of rule_error
 
@@ -149,7 +147,7 @@ let pp_rule_infos out r =
       pat = pattern_of_rule_infos r;
       rhs = r.rhs
     }
-    
+
 let pattern_to_term p =
   let rec aux k = function
     | Brackets t         -> t
@@ -226,13 +224,10 @@ let check_patterns (esize:int) (pats:pattern list) : wf_pattern list * pattern_i
       if not (all_distinct args')
       then raise (RuleExn (DistinctBoundVariablesExpected (l,x)));
       let nb_args' = List.length args' in
-      if IntHashtbl.mem arity (n-k)
-      then if nb_args' <> IntHashtbl.find arity (n-k)
-        then raise (RuleExn (NonLinearNonEqArguments(l,x)))
-        else
-          let nvar = fresh_var nb_args' in 
-          constraints := Linearity(nvar, n-k) :: !constraints;
-          LVar(x, nvar + k, args')
+      if IntHashtbl.mem arity (n-k) then
+        let nvar = fresh_var nb_args' in
+        constraints := Linearity(nvar, n-k) :: !constraints;
+        LVar(x, nvar + k, args')
       else
         let _ = IntHashtbl.add arity (n-k) nb_args' in
         LVar(x,n,args')
@@ -253,25 +248,6 @@ let check_patterns (esize:int) (pats:pattern list) : wf_pattern list * pattern_i
       arity = Array.init !context_size (fun i -> IntHashtbl.find arity i)
     } )
 
-(* Checks that the lhs variables are applied to enough arguments *)
-let check_nb_args (arity:int array) (rhs:term) : unit =
-  let check l id n k nargs =
-    let expected_args = arity.(n-k) in
-    if nargs < expected_args
-    then raise (RuleExn (NotEnoughArguments (l,id,n,nargs,expected_args))) in
-  let rec aux k = function
-    | Kind | Type _ | Const _ -> ()
-    | DB (l,id,n) ->
-      if n >= k then check l id n k 0
-    | App(DB(l,id,n),a1,args) when n>=k ->
-      check l id n k (List.length args + 1);
-      List.iter (aux k) (a1::args)
-    | App (f,a1,args) -> List.iter (aux k) (f::a1::args)
-    | Lam (_,_,None,b) -> aux (k+1) b
-    | Lam (_,_,Some a,b) | Pi (_,_,a,b) -> (aux k a;  aux (k+1) b)
-  in
-  aux 0 rhs
-
 let to_rule_infos (r:untyped_rule) : (rule_infos,rule_error) error =
   let is_linear = List.for_all (function Linearity _ -> false | _ -> true) in
   try
@@ -282,17 +258,14 @@ let to_rule_infos (r:untyped_rule) : (rule_infos,rule_error) error =
       | Lambda _ | Brackets _ -> assert false (* already raised at the parsing level *)
     in
     let (pats2,infos) = check_patterns esize args in
-    
-    (* Checking that Miller variable are correctly applied in lhs *)
-    check_nb_args infos.arity r.rhs;
-    
+
     (* Checking if pattern has linearity constraints *)
     if not (is_linear infos.constraints)
     then
       if !allow_non_linear
       then Debug.(debug d_rule "Non-linear Rewrite Rule detected")
       else raise (RuleExn (NonLinearRule r));
-    
+
     OK { l ; name = r.name ; cst ; args ; rhs = r.rhs ;
          esize = infos.context_size ;
          pats = Array.of_list pats2 ;

--- a/kernel/rule.mli
+++ b/kernel/rule.mli
@@ -65,8 +65,6 @@ type rule_error =
   | UnboundVariable                of loc * ident * pattern
   | AVariableIsNotAPattern         of loc * ident
   | NonLinearRule                  of untyped_rule
-  | NotEnoughArguments             of loc * ident * int * int * int
-  | NonLinearNonEqArguments        of loc * ident
 
 (** {2 Rule infos} *)
 

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -23,6 +23,9 @@ type typing_error =
   | Unconvertible of loc*term*term
   | Convertible of loc*term*term
   | Inhabit of loc*term*term
+  | NonLinearNonEqArguments        of loc * ident
+  (* FIXME: the reason for this exception should be formalized on paper ! *)
+  | NotEnoughArguments             of loc * ident * int * int * int
 
 exception TypingError of typing_error
 


### PR DESCRIPTION
This criterion is a type checking criterion, not a matching one. Hence, I think it should be checked only while typing a rule.