### PR TITLE
Add an explicit type for the module Env

### DIFF
--- a/api/env.ml
+++ b/api/env.ml
@@ -4,6 +4,8 @@ open Rule
 open Typing
 open Signature
 
+type t = Signature.t
+
 exception DebugFlagNotRecognized of char
 
 let set_debug_mode =
@@ -28,50 +30,50 @@ type env_error =
   | ParseError          of string
   | AssertError
 
-exception EnvError of loc * env_error
+exception EnvError of t * loc * env_error
 
-let raise_as_env lc = function
-  | SignatureError e -> raise (EnvError (lc, (EnvErrorSignature e)))
-  | TypingError    e -> raise (EnvError (lc, (EnvErrorType      e)))
+let raise_as_env sg lc = function
+  | SignatureError e -> raise (EnvError (sg, lc, (EnvErrorSignature e)))
+  | TypingError    e -> raise (EnvError (sg, lc, (EnvErrorType      e)))
   | ex -> raise ex
 
 
 (* Wrapper around Signature *)
 
-let sg = ref (Signature.make "noname")
+let check_arity = ref true
 
-let check_arity     = ref true
+let get_md = Signature.get_md
 
 let init file =
-  sg := Signature.make file;
-  Signature.get_name !sg
+  let sg = Signature.make file in
+  let md = get_md sg in
+  Pp.set_module md;
+  sg
 
-let get_name () = Signature.get_name !sg
+let get_signature sg = sg
 
-let get_signature () = !sg
+let get_type sg lc cst =
+  try Signature.get_type sg lc cst
+  with e -> raise_as_env sg lc e
 
-let get_type lc cst =
-  try Signature.get_type !sg lc cst
-  with e -> raise_as_env lc e
+let get_dtree sg lc cst =
+  try Signature.get_dtree sg None lc cst
+  with e -> raise_as_env sg lc e
 
-let get_dtree lc cst =
-  try Signature.get_dtree !sg None lc cst
-  with e -> raise_as_env lc e
+let export sg =
+  try Signature.export sg
+  with e -> raise_as_env sg dloc e
 
-let export () =
-  try Signature.export !sg
-  with e -> raise_as_env dloc e
+let import sg lc md =
+  try Signature.import sg lc md
+  with e -> raise_as_env sg lc e
 
-let import lc md =
-  try Signature.import !sg lc md
-  with e -> raise_as_env lc e
-
-let _declare lc (id:ident) st ty : unit =
-  match inference !sg ty with
-  | Kind | Type _ -> Signature.add_declaration !sg lc id st ty
+let _declare sg lc (id:ident) st ty : unit =
+  match inference sg ty with
+  | Kind | Type _ -> Signature.add_declaration sg lc id st ty
   | s -> raise (TypingError (SortExpected (ty,[],s)))
 
-let is_static lc cst = Signature.is_static !sg lc cst
+let is_static sg lc cst = Signature.is_static sg lc cst
 
 
 (*         Rule checking       *)
@@ -79,11 +81,11 @@ let is_static lc cst = Signature.is_static !sg lc cst
 (** Checks that all Miller variables are applied to the same number of
     distinct free variable on the left hand side.
     Checks that they are applied to at least as many arguments on the rhs.  *)
-let _check_arity (r:rule_infos) : unit =
+let _check_arity sg (r:rule_infos) : unit =
   let check l id n k nargs =
     let expected_args = r.arity.(n-k) in
     if nargs < expected_args
-    then raise (EnvError (l, NotEnoughArguments (id,n,nargs,expected_args))) in
+    then raise (EnvError (sg, l, NotEnoughArguments (id,n,nargs,expected_args))) in
   let rec aux k = function
     | Kind | Type _ | Const _ -> ()
     | DB (l,id,n) ->
@@ -97,23 +99,23 @@ let _check_arity (r:rule_infos) : unit =
   in
   aux 0 r.rhs
 
-let _add_rules rs =
+let _add_rules sg rs =
   let ris = List.map Rule.to_rule_infos rs in
-  if !check_arity then List.iter _check_arity ris;
-  Signature.add_rules !sg ris
+  if !check_arity then List.iter (_check_arity sg) ris;
+  Signature.add_rules sg ris
 
-let _define lc (id:ident) (opaque:bool) (te:term) (ty_opt:typ option) : unit =
+let _define sg lc (id:ident) (opaque:bool) (te:term) (ty_opt:typ option) : unit =
   let ty = match ty_opt with
-    | None -> inference !sg te
-    | Some ty -> ( checking !sg te ty; ty )
+    | None -> inference sg te
+    | Some ty -> ( checking sg te ty; ty )
   in
   match ty with
-  | Kind -> raise (EnvError (lc, KindLevelDefinition id))
+  | Kind -> raise (EnvError (sg, lc, KindLevelDefinition id))
   | _ ->
-    if opaque then Signature.add_declaration !sg lc id Signature.Static ty
+    if opaque then Signature.add_declaration sg lc id Signature.Static ty
     else
-      let _ = Signature.add_declaration !sg lc id Signature.Definable ty in
-      let cst = mk_name (get_name ()) id in
+      let _ = Signature.add_declaration sg lc id Signature.Definable ty in
+      let cst = mk_name (get_md sg) id in
       let rule =
         { name= Delta(cst) ;
           ctx = [] ;
@@ -121,53 +123,53 @@ let _define lc (id:ident) (opaque:bool) (te:term) (ty_opt:typ option) : unit =
           rhs = te ;
         }
       in
-      _add_rules [rule]
+      _add_rules sg [rule]
 
-let declare lc id st ty : unit =
-  try _declare lc id st ty
-  with e -> raise_as_env lc e
+let declare sg lc id st ty : unit =
+  try _declare sg lc id st ty
+  with e -> raise_as_env sg lc e
 
-let define lc id op te ty_opt : unit =
-  try _define lc id op te ty_opt
-  with e -> raise_as_env lc e
+let define sg lc id op te ty_opt : unit =
+  try _define sg lc id op te ty_opt
+  with e -> raise_as_env sg lc e
 
-let add_rules (rules: untyped_rule list) : (Subst.Subst.t * typed_rule) list =
+let add_rules sg (rules: untyped_rule list) : (Subst.Subst.t * typed_rule) list =
   try
-    let rs2 = List.map (check_rule !sg) rules in
-    _add_rules rules;
+    let rs2 = List.map (check_rule sg) rules in
+    _add_rules sg rules;
     rs2
-  with e -> raise_as_env (get_loc_rule (List.hd rules)) e
+  with e -> raise_as_env sg (get_loc_rule (List.hd rules)) e
 
-let infer ?ctx:(ctx=[]) te =
+let infer sg ?ctx:(ctx=[]) te =
   try
-    let ty = infer !sg ctx te in
-    ignore(infer !sg ctx ty);
+    let ty = infer sg ctx te in
+    ignore(infer sg ctx ty);
     ty
-  with e -> raise_as_env (get_loc te) e
+  with e -> raise_as_env sg (get_loc te) e
 
-let check ?ctx:(ctx=[]) te ty =
-  try check !sg ctx te ty
-  with e -> raise_as_env (get_loc te) e
+let check sg ?ctx:(ctx=[]) te ty =
+  try check sg ctx te ty
+  with e -> raise_as_env sg (get_loc te) e
 
-let _unsafe_reduction red te =
-  Reduction.reduction red !sg te
+let _unsafe_reduction sg red te =
+  Reduction.reduction red sg te
 
-let _reduction ctx red te =
-  ignore(Typing.infer !sg ctx te);
-  _unsafe_reduction red te
+let _reduction sg ctx red te =
+  ignore(Typing.infer sg ctx te);
+  _unsafe_reduction sg red te
 
-let reduction ?ctx:(ctx=[]) ?red:(red=Reduction.default_cfg) te =
-  try _reduction ctx red te
-  with e -> raise_as_env (get_loc te) e
+let reduction sg ?ctx:(ctx=[]) ?red:(red=Reduction.default_cfg) te =
+  try _reduction sg ctx red te
+  with e -> raise_as_env sg (get_loc te) e
 
-let unsafe_reduction ?red:(red=Reduction.default_cfg) te =
-  try _unsafe_reduction red te
-  with e -> raise_as_env (get_loc te) e
+let unsafe_reduction sg ?red:(red=Reduction.default_cfg) te =
+  try _unsafe_reduction sg red te
+  with e -> raise_as_env sg (get_loc te) e
 
-let are_convertible ?ctx:(ctx=[]) te1 te2 =
+let are_convertible sg ?ctx:(ctx=[]) te1 te2 =
   try
-    let ty1 = Typing.infer !sg ctx te1 in
-    let ty2 = Typing.infer !sg ctx te2 in
-    Reduction.are_convertible !sg ty1 ty2 &&
-    Reduction.are_convertible !sg te1 te2
-  with e -> raise_as_env (get_loc te1) e
+    let ty1 = Typing.infer sg ctx te1 in
+    let ty2 = Typing.infer sg ctx te2 in
+    Reduction.are_convertible sg ty1 ty2 &&
+    Reduction.are_convertible sg te1 te2
+  with e -> raise_as_env sg (get_loc te1) e

--- a/api/env.mli
+++ b/api/env.mli
@@ -3,6 +3,8 @@
 open Basic
 open Term
 
+type t
+
 (** {2 Error Datatype} *)
 
 type env_error =
@@ -14,7 +16,7 @@ type env_error =
   | ParseError          of string
   | AssertError
 
-exception EnvError of loc * env_error
+exception EnvError of t * loc * env_error
 
 (** {2 Debugging} *)
 
@@ -38,62 +40,62 @@ val check_arity : bool ref
 
 (** {2 The Global Environment} *)
 
-val init        : string -> mident
+val init        : string -> t
 (** [init name] initializes a new global environement giving it the name of
     the corresponding source file. The function returns the module identifier
     corresponding to this file, built from its basename. Every toplevel
     declaration will be qualified by this name. *)
 
-val get_signature : unit -> Signature.t
+val get_signature : t -> Signature.t
 (** [get_signature ()] returns the signature used by this module. *)
 
-val get_name    : unit -> mident
-(** [get_name ()] returns the name of the module. *)
+val get_md      : t -> mident
+(** [get_md ()] returns the name of the module. *)
 
-val get_type    : loc -> name -> term
+val get_type    : t -> loc -> name -> term
 (** [get_type l md id] returns the type of the constant [md.id]. *)
 
-val is_static   : loc -> name -> bool
+val is_static   : t -> loc -> name -> bool
 (** [is_static l cst] returns [true] if the symbol is declared as [static], [false] otherwise *)
 
-val get_dtree   : loc -> name -> Dtree.t
+val get_dtree   : t -> loc -> name -> Dtree.t
 (** [get_dtree l md id] returns the decision/matching tree associated with [md.id]. *)
 
-val export      : unit -> unit
+val export      : t -> unit
 (** [export ()] saves the current environment in a [*.dko] file. *)
 
-val import      : loc -> mident -> unit
+val import      : t -> loc -> mident -> unit
 (** [import lc md] the module [md] in the current environment. *)
 
-val declare     : loc -> ident -> Signature.staticity -> term -> unit
+val declare     : t -> loc -> ident -> Signature.staticity -> term -> unit
 (** [declare_constant l id st ty] declares the symbol [id] of type [ty] and
    staticity [st]. *)
 
-val define      : loc -> ident -> bool -> term -> term option -> unit
+val define      : t -> loc -> ident -> bool -> term -> term option -> unit
 (** [define l id body ty] defined the symbol [id] of type [ty] to be an alias of [body]. *)
 
-val add_rules   : Rule.untyped_rule list -> (Subst.Subst.t * Rule.typed_rule) list
+val add_rules   : t -> Rule.untyped_rule list -> (Subst.Subst.t * Rule.typed_rule) list
 (** [add_rules rule_lst] adds a list of rule to a symbol. All rules must be on the
     same symbol. *)
 
 (** {2 Type checking/inference} *)
 
-val infer : ?ctx:typed_context -> term         -> term
+val infer : t -> ?ctx:typed_context -> term         -> term
 (** [infer ctx term] infers the type of [term] given the typed context [ctx] *)
 
-val check : ?ctx:typed_context -> term -> term -> unit
+val check : t -> ?ctx:typed_context -> term -> term -> unit
 (** [infer ctx te ty] checks that [te] is of type [ty] given the typed context [ctx] *)
 
 (** {2 Safe Reduction/Conversion} *)
 (** terms are typechecked before the reduction/conversion *)
 
-val reduction : ?ctx:typed_context -> ?red:(Reduction.red_cfg) -> term -> term
+val reduction : t -> ?ctx:typed_context -> ?red:(Reduction.red_cfg) -> term -> term
 (** [reduction ctx red te] checks first that [te] is well-typed then reduces it
     according to the reduction configuration [red] *)
 
-val are_convertible : ?ctx:typed_context -> term -> term -> bool
+val are_convertible : t -> ?ctx:typed_context -> term -> term -> bool
 (** [are_convertible ctx tl tr] checks first that [tl] [tr] have the same type,
     and then that they are convertible *)
 
-val unsafe_reduction : ?red:(Reduction.red_cfg) -> term -> term
+val unsafe_reduction : Signature.t -> ?red:(Reduction.red_cfg) -> term -> term
 (** [unsafe_reduction red te] reduces [te] according to the reduction configuration [red] *)

--- a/api/errors.mli
+++ b/api/errors.mli
@@ -12,7 +12,7 @@ val success : ('a, Format.formatter, unit) format -> 'a
 val fail_exit : int -> loc -> ('a, Format.formatter, unit) format -> 'a
 (** Print an error message with given code and and exit. *)
 
-val fail_env_error : loc -> Env.env_error -> 'a
+val fail_env_error : Env.t -> loc -> Env.env_error -> 'a
 (** Prints a message explaining the env_error then exits with code 3. *)
 
 val fail_sys_error : string -> 'a

--- a/api/pp.ml
+++ b/api/pp.ml
@@ -3,8 +3,6 @@ open Term
 open Rule
 open Printf
 open Entry
-open Env
-(* FIXME: this module is highly redondant with printing functions insides kernel modules *)
 
 (* TODO: make that debuging functions returns a string *)
 let print_db_enabled = ref false
@@ -13,11 +11,12 @@ let print_default_name = ref false
 let cur_md = ref None
 let get_module () =
   match !cur_md with
-  | None -> get_name ()
+  | None -> mk_mident "" (* Modules will always be printed *)
   | Some md -> md
 
 let set_module md =
   cur_md := Some md
+
 let rec print_list = pp_list
 
 let print_ident = pp_ident
@@ -129,7 +128,7 @@ let print_rule_name fmt rule =
   let aux b cst =
     if b || !print_default_name
     then
-      if mident_eq (md cst) (get_name ())
+      if mident_eq (md cst) (get_module ())
       then Format.fprintf fmt "@[<h>{%a}@] " print_ident (id cst)
       else Format.fprintf fmt "@[<h>{%a}@] " print_name cst
   in

--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -6,69 +6,70 @@ open Entry
 let eprint lc fmt =
   Debug.(debug D_notice ("%a " ^^ fmt) pp_loc lc)
 
-let mk_entry md e =
+let mk_entry env md e =
   match e with
   | Decl(lc,id,st,ty) ->
     eprint lc "Declaration of constant '%a'." pp_ident id;
-    Env.declare lc id st ty
+    Env.declare env lc id st ty
   | Def(lc,id,opaque,ty,te) ->
     let opaque_str = if opaque then " (opaque)" else "" in
     eprint lc "Definition of symbol '%a'%s." pp_ident id opaque_str;
-    Env.define lc id opaque te ty
+    Env.define env lc id opaque te ty
   | Rules(l,rs) ->
     let open Rule in
     List.iter (fun (r:untyped_rule) -> eprint l "Adding rewrite rules: '%a'" Pp.print_rule_name r.name) rs;
-    let rs = Env.add_rules rs in
+    let rs = Env.add_rules env rs in
     List.iter (fun (s,r) ->
         eprint (get_loc_pat r.pat) "%a@.with the following constraints: %a"
           pp_typed_rule r Subst.Subst.pp s) rs
   | Eval(_,red,te) ->
-    let te = Env.reduction ~red te in
+    let te = Env.reduction env ~red te in
     Format.printf "%a@." Pp.print_term te
   | Infer(_,red,te) ->
-    let  ty = Env.infer te in
-    let rty = Env.reduction ~red ty in
+    let  ty = Env.infer env te in
+    let rty = Env.reduction env ~red ty in
     Format.printf "%a@." Pp.print_term rty
   | Check(l, assrt, neg, Convert(t1,t2)) ->
-    let succ = (Env.are_convertible t1 t2) <> neg in
+    let succ = (Env.are_convertible env t1 t2) <> neg in
     ( match succ, assrt with
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (l,Env.AssertError)) )
+      | false, true  -> raise (Env.EnvError (env,l,Env.AssertError)) )
   | Check(l, assrt, neg, HasType(te,ty)) ->
-    let succ = try Env.check te ty; not neg with _ -> neg in
+    let succ = try Env.check env te ty; not neg with _ -> neg in
     ( match succ, assrt with
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (l, Env.AssertError)) )
+      | false, true  -> raise (Env.EnvError (env, l, Env.AssertError)) )
   | DTree(lc,m,v) ->
-    let m = match m with None -> Env.get_name () | Some m -> m in
+    let m = match m with None -> Env.get_md env | Some m -> m in
     let cst = mk_name m v in
-    let forest = Env.get_dtree lc cst in
+    let forest = Env.get_dtree env lc cst in
     Format.printf "GDTs for symbol %a:@.%a" pp_name cst Dtree.pp_dforest forest
   | Print(_,s) -> Format.printf "%s@." s
   | Name(_,n) ->
     if not (mident_eq n md)
     then Debug.(debug D_warn "Invalid #NAME directive ignored.@.")
-  | Require(lc,md) -> Env.import lc md
+  | Require(lc,md) -> Env.import env lc md
 
-let mk_entry beautify md =
+let mk_entry beautify env md =
   if beautify then Pp.print_entry Format.std_formatter
-  else mk_entry md
+  else mk_entry env md
 
 
 let run_on_file beautify export file =
   let input = open_in file in
   Debug.(debug Signature.D_module "Processing file '%s'..." file);
-  let md = Env.init file in
+  let env = Env.init file in
+  let md = Env.get_md env in
   Confluence.initialize ();
-  Parser.handle_channel md (mk_entry beautify md) input;
+  Parser.handle_channel md (mk_entry beautify env md) input;
   if not beautify then
     Errors.success "File '%s' was successfully checked." file;
   if export then
-    Env.export ();
+    Env.export env;
   Confluence.finalize ();
   close_in input
 
@@ -138,10 +139,11 @@ let _ =
     match !run_on_stdin with
     | None   -> ()
     | Some m ->
-      let md = Env.init m in
-      Parser.handle_channel md (mk_entry !beautify md) stdin;
+      let env = Env.init m in
+      let md = Env.get_md env in
+      Parser.handle_channel md (mk_entry !beautify env md) stdin;
       if not !beautify
       then Errors.success "Standard input was successfully checked.\n"
   with
-  | Env.EnvError (l,e) -> Errors.fail_env_error l e
+  | Env.EnvError (env,l,e) -> Errors.fail_env_error env l e
   | Sys_error err  -> Errors.fail_sys_error err

--- a/commands/dkdep.ml
+++ b/commands/dkdep.ml
@@ -109,7 +109,7 @@ let handle_file : string -> dep_data = fun file ->
     close_in input;
     (md, (file, !current_deps))
   with
-  | Env.EnvError (l,e)   -> Errors.fail_env_error l e
+  | Env.EnvError (env,l,e)   -> Errors.fail_env_error env l e
   | Sys_error err        -> Errors.fail_sys_error err
 
 (** Output main program. *)

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -7,56 +7,57 @@ open Errors
 let print fmt =
   Format.kfprintf (fun _ -> print_newline () ) Format.std_formatter fmt
 
-let handle_entry e =
+let handle_entry env e =
   match e with
   | Decl(lc,id,st,ty) ->
-    Env.declare lc id st ty;
+    Env.declare env lc id st ty;
     Format.printf "%a is declared.@." pp_ident id
   | Def(lc,id,op,ty,te) ->
-    Env.define lc id op te ty;
+    Env.define env lc id op te ty;
     Format.printf "%a is defined.@." pp_ident id
   | Rules(_,rs) ->
-    let _ = Env.add_rules rs in
+    let _ = Env.add_rules env rs in
     List.iter (fun r -> print "%a" Rule.pp_untyped_rule r) rs
   | Eval(lc,red,te) ->
-    let te = Env.reduction ~red te in
+    let te = Env.reduction env ~red te in
     Format.printf "%a@." Pp.print_term te
   | Infer(_,red,te) ->
-    let  ty = Env.infer te in
-    let rty = Env.reduction ~red ty in
+    let  ty = Env.infer env te in
+    let rty = Env.reduction env ~red ty in
     Format.printf "%a@." Pp.print_term rty
   | Check(l, assrt, neg, Convert(t1,t2)) ->
-    let succ = (Env.are_convertible t1 t2) <> neg in
+    let succ = (Env.are_convertible env t1 t2) <> neg in
     ( match succ, assrt with
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (l, Env.AssertError)) )
+      | false, true  -> raise (Env.EnvError (env,l, Env.AssertError)) )
   | Check(l, assrt, neg, HasType(te,ty)) ->
-    let succ = try Env.check te ty; not neg with _ -> neg in
+    let succ = try Env.check env te ty; not neg with _ -> neg in
     ( match succ, assrt with
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (l, Env.AssertError)) )
+      | false, true  -> raise (Env.EnvError (env,l, Env.AssertError)) )
   | DTree(lc,m,v) ->
-    let m = match m with None -> Env.get_name () | Some m -> m in
+    let m = match m with None -> Env.get_md env | Some m -> m in
     let cst = mk_name m v in
-    let forest = Env.get_dtree lc cst in
+    let forest = Env.get_dtree env lc cst in
     Format.printf "GDTs for symbol %a:\n%a" pp_name cst Dtree.pp_dforest forest
   | Print(_,s) -> Format.printf "%s@." s
   | Name _     -> Format.printf "\"#NAME\" directive ignored.@."
   | Require _  -> Format.printf "\"#REQUIRE\" directive ignored.@."
 
 let  _ =
-  let md = Env.init "<toplevel>" in
+  let env = Env.init "<toplevel>" in
+  let md = Env.get_md env in
   let str = from_channel md stdin in
   Format.printf "\tDedukti (%s)@.@." Version.version;
   while true do
     Format.printf ">> ";
-    try handle_entry (read str) with
+    try handle_entry env (read str) with
     | End_of_file -> exit 0
-    | Env.EnvError (l, Env.ParseError s) -> Errors.fail_env_error l (Env.ParseError s)
+    | Env.EnvError (env, l, Env.ParseError s) -> Errors.fail_env_error env l (Env.ParseError s)
     | e ->
       Format.eprintf "Uncaught exception %S@." (Printexc.to_string e)
   done

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -62,7 +62,7 @@ let make file =
   HMd.add tables name (HId.create 251);
   { name; file; tables; external_rules=[]; }
 
-let get_name sg = sg.name
+let get_md sg = sg.name
 
 (******************************************************************************)
 
@@ -123,7 +123,7 @@ let read_dko lc m =
   in
   HId.iter treat_unmarshaled ctx;
   deps,!mod_sig,ext
-  
+
 
 (******************************************************************************)
 

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -30,7 +30,7 @@ type t
 val make                : string -> t
 (** [make file] creates a new signature corresponding to the file [file]. *)
 
-val get_name            : t -> mident
+val get_md              : t -> mident
 (** [get_name sg] returns the name of the signature [sg]. *)
 
 val export              : t -> unit

--- a/parser/lexer.mll
+++ b/parser/lexer.mll
@@ -11,7 +11,7 @@
   let prerr_loc lc = eprintf "%a " pp_loc lc
 
   let fail lc msg =
-    raise (Env.EnvError (lc, Env.ParseError msg))
+    raise (Env.EnvError (Env.init "", lc, Env.ParseError msg))
 }
 
 let space   = [' ' '\t' '\r']

--- a/parser/menhir_parser.mly
+++ b/parser/menhir_parser.mly
@@ -35,7 +35,7 @@ let mk_config loc lid =
       nb_steps = (!nb_steps);
       target   = (match !target with None -> default_cfg.target | Some t -> t);
       strat    = (match !strat  with None -> default_cfg.strat  | Some s -> s) }
-  with _ -> raise (Env.EnvError (loc, Env.ParseError "invalid command configuration"))
+  with _ -> raise (Env.EnvError (Env.init "", loc, Env.ParseError "invalid command configuration"))
 
 let loc_of_rs = function
   | [] -> assert false

--- a/parser/parser.ml
+++ b/parser/parser.ml
@@ -12,7 +12,7 @@ let read str =
     let loc = Lexer.get_loc str.lexbuf in
     let lex = Lexing.lexeme str.lexbuf in
     let msg = Format.sprintf "Unexpected token '%s'." lex in
-    raise (Env.EnvError (loc, Env.ParseError msg))
+    raise (Env.EnvError (Env.init "", loc, Env.ParseError msg))
 
 let handle_channel md f ic =
   let s = from_channel md ic in

--- a/parser/scoping.ml
+++ b/parser/scoping.ml
@@ -117,7 +117,7 @@ let scope_rule md (l,pname,pctx,md_opt,id,pargs,pri:prule) : untyped_rule =
   let name =
     let md = match pname with
       | Some (Some md, _) -> md
-      | _ -> Env.get_name ()
+      | _ -> Pp.get_module ()
     in
     Gamma(b,mk_name md id)
   in


### PR DESCRIPTION
Add an explicit type for the module `Env`. This way, it makes easier to use the API with several environments. This PR could be a first step to enhance error messages. 