### PR TITLE
Export the signature

### DIFF
--- a/api/errors.ml
+++ b/api/errors.ml
@@ -169,8 +169,8 @@ let fail_signature_error def_loc err =
     fail lc "Fail to open module '%s'." md
   | SymbolNotFound (lc,cst) ->
     fail lc "Cannot find symbol '%a'." pp_name cst
-  | AlreadyDefinedSymbol (lc,id) ->
-    fail lc "Already declared symbol '%a'." pp_ident id
+  | AlreadyDefinedSymbol (lc,n) ->
+    fail lc "Already declared symbol '%a'." pp_name n
   | CannotBuildDtree err -> fail_dtree_error err
   | CannotMakeRuleInfos err -> fail_rule_error err
   | CannotAddRewriteRules (lc,id) ->

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -146,7 +146,10 @@ let access_signature sg =
     (fun md t ->
       HId.iter
         (fun id r ->
-          res:=(symbol_infos_crafting md id r)::!res
+          (* We don't want to export several time the same symbol, but only the
+             most recent version stored in [t] *)
+          if HId.find t id =r
+          then res:=(symbol_infos_crafting md id r)::!res
         ) t
     ) sg.tables;
   List.iter

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -111,7 +111,7 @@ let unmarshal (lc:loc) (m:string) : string list * rw_infos HId.t * rule_infos li
   | SignatureError s -> raise (SignatureError s)
   | _ -> raise (SignatureError (UnmarshalUnknown (lc,m)))
 
-let access_signature sg =
+let symbols_of sg =
   let add_in_symbol_infos (f : name) (r : rule_infos) =
     let rec aux (acc : symbol_infos list) =
       function
@@ -178,7 +178,6 @@ and add_rule_infos sg (lst:rule_infos list) : unit =
   | (r::_ as rs) ->
     let env = get_env sg r.l r.cst in
     let infos : rw_infos = get_info_env r.l env r.cst in
-    let ty = infos.ty in
     if infos.stat = Static
     then raise (SignatureError (CannotAddRewriteRules (r.l,(id r.cst))));
     let rules = (infos.rules @ rs) in
@@ -187,7 +186,7 @@ and add_rule_infos sg (lst:rule_infos list) : unit =
       with Dtree.DtreeError e -> raise (SignatureError (CannotBuildDtree e))
     in
     HId.add env (id r.cst)
-      {stat = infos.stat; ty=ty; rules = rules; decision_tree=Some(trees)}
+      {infos with rules = rules; decision_tree=Some(trees)}
 
 and get_env sg lc cst =
   let md = md cst in

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -135,8 +135,7 @@ let access_signature sg =
          else aux (s::acc) tl
     in aux []
   in
-  let symbol_infos_crafting : mident -> ident -> rw_infos -> symbol_infos =
-    fun md id r ->
+  let symbol_infos_crafting (md : mident) (id : ident) (r : rw_infos) =
     { ident  = mk_name md id
     ; ty    = r.ty
     ; rules = default_first [] r.rule_opt_info

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -24,6 +24,14 @@ exception SignatureError of signature_error
 
 type staticity = Static | Definable
 
+type symbol_infos =
+  {
+    name  : name;
+    stat  : staticity;
+    ty    : term;
+    rules : rule_infos list
+  }
+
 type t
 
 val make                : string -> t
@@ -65,8 +73,5 @@ val add_rules           : t -> Rule.rule_infos list -> unit
 (** [add_rules sg rule_lst] adds a list of rule to a symbol in the environement [sg].
     All rules must be on the same symbol. *)
 
-val read_dko : loc -> string -> string list * (ident * staticity * term * rule_infos list) list * rule_infos list list
-(** [read_dko lc md] returns a triple containing all the informations of the [md.dko] file:
- - The list of modules on which md depends,
- - The list of symbols and rules declared in this module,
- - The list of rules declared on this module and defining symbols declared in another module. *)
+val access_signature : t ->  symbol_infos list
+(** [access_signature sg] returns the content of the signature [sg]. *)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -11,7 +11,7 @@ type signature_error =
   | UnmarshalSysError     of loc * string * string
   | UnmarshalUnknown      of loc * string
   | SymbolNotFound        of loc * name
-  | AlreadyDefinedSymbol  of loc * ident
+  | AlreadyDefinedSymbol  of loc * name
   | CannotMakeRuleInfos   of Rule.rule_error
   | CannotBuildDtree      of Dtree.dtree_error
   | CannotAddRewriteRules of loc * ident

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -24,13 +24,15 @@ exception SignatureError of signature_error
 
 type staticity = Static | Definable
 
-type symbol_infos =
+type rw_infos =
   {
-    ident : name;
-    stat  : staticity;
-    ty    : term;
-    rules : rule_infos list
+    stat          : staticity;
+    ty            : term;
+    rules         : rule_infos list;
+    decision_tree : Dtree.t option
   }
+
+type symbol_infos = name * rw_infos
 
 type t
 

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -65,6 +65,10 @@ val get_dtree           : t -> (Rule.rule_name -> bool) option -> loc -> name ->
 val get_rules           : t -> loc -> name -> rule_infos list
 (** [get_rules sg lc cst] returns a list of rules that defines the symbol. *)
 
+val add_external_declaration     : t -> loc -> name -> staticity -> term -> unit
+(** [add_external_declaration sg l cst st ty] declares the symbol [id] of type
+    [ty] and staticity [st] in the environment [sg]. *)
+
 val add_declaration     : t -> loc -> ident -> staticity -> term -> unit
 (** [add_declaration sg l id st ty] declares the symbol [id] of type [ty]
     and staticity [st] in the environment [sg]. *)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -79,5 +79,5 @@ val add_rules           : t -> Rule.rule_infos list -> unit
 (** [add_rules sg rule_lst] adds a list of rule to a symbol in the environement [sg].
     All rules must be on the same symbol. *)
 
-val access_signature : t ->  symbol_infos list
+val symbols_of : t ->  symbol_infos list
 (** [access_signature sg] returns the content of the signature [sg]. *)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -26,7 +26,7 @@ type staticity = Static | Definable
 
 type symbol_infos =
   {
-    name  : name;
+    ident : name;
     stat  : staticity;
     ty    : term;
     rules : rule_infos list


### PR DESCRIPTION
This PR remove the useless function `read_dko` and replace it by a function `access_signature` which gives the user access to the content of the signature given in argument.