### PR TITLE
Rule_infos_to_typed_rule in typing.ml

### DIFF
--- a/kernel/rule.mli
+++ b/kernel/rule.mli
@@ -85,8 +85,9 @@ type rule_infos = {
   arity       : int array;        (** arities of context variables *)
   constraints : constr list;
   (** constraints generated from the pattern to the free pattern *)
-}
+  }
 
+val infer_rule_context : rule_infos -> untyped_context
 val pattern_of_rule_infos : rule_infos -> pattern
 
 val to_rule_infos : untyped_rule -> rule_infos

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -399,3 +399,11 @@ let check_rule sg (rule:untyped_rule) : SS.t * typed_rule =
     pat = rule.pat;
     rhs = rule.rhs
   }
+
+let typed_rule_of_ri s ri =
+  let ur =
+    { name = ri.name
+    ; ctx  = infer_rule_context ri
+    ; pat  = pattern_of_rule_infos ri
+    ; rhs  = ri.rhs} in
+  snd (check_rule s ur)

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -400,10 +400,10 @@ let check_rule sg (rule:untyped_rule) : SS.t * typed_rule =
     rhs = rule.rhs
   }
 
-let typed_rule_of_ri s ri =
+let typed_rule_of_rule_infos s ri =
   let ur =
     { name = ri.name
     ; ctx  = infer_rule_context ri
     ; pat  = pattern_of_rule_infos ri
     ; rhs  = ri.rhs} in
-  snd (check_rule s ur)
+  check_rule s ur

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -53,3 +53,5 @@ val inference   : Signature.t -> term -> typ
 
 val check_rule  : Signature.t -> untyped_rule -> Subst.Subst.t * typed_rule
 (** [check_rule sg ru] checks that a rule is well-typed. *)
+
+val typed_rule_of_ri : Signature.t -> rule_infos -> typed_rule

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -54,4 +54,4 @@ val inference   : Signature.t -> term -> typ
 val check_rule  : Signature.t -> untyped_rule -> Subst.Subst.t * typed_rule
 (** [check_rule sg ru] checks that a rule is well-typed. *)
 
-val typed_rule_of_ri : Signature.t -> rule_infos -> typed_rule
+val typed_rule_of_rule_infos : Signature.t -> rule_infos -> Subst.Subst.t * typed_rule


### PR DESCRIPTION
It is required for external usage to have a way from a signature and a rule_infos to get the typed environment inferred.