### PR TITLE
Make #INFER Type produce KIND

### DIFF
--- a/tests/KO/arrowCodomainType.dk
+++ b/tests/KO/arrowCodomainType.dk
@@ -1,0 +1,4 @@
+(; KO 3 ;)
+
+A : Type.
+#INFER (A -> Type) -> A.

--- a/tests/KO/arrowDomainType.dk
+++ b/tests/KO/arrowDomainType.dk
@@ -1,0 +1,4 @@
+(; KO 3 ;)
+
+A : Type.
+#INFER Type -> A.

--- a/tests/KO/arrowDomainType2.dk
+++ b/tests/KO/arrowDomainType2.dk
@@ -1,0 +1,4 @@
+(; KO 3 ;)
+
+A : Type.
+#INFER (Type -> A) -> A.

--- a/tests/KO/kind_typable_2.dk
+++ b/tests/KO/kind_typable_2.dk
@@ -1,3 +1,0 @@
-(; KO 2 ;)
-
-#INFER Type.

--- a/tests/KO/typeArrowType.dk
+++ b/tests/KO/typeArrowType.dk
@@ -1,0 +1,3 @@
+(; KO 3 ;)
+
+#INFER Type -> Type.

--- a/tests/OK/inferingKindForArrowWithCodomainType.dk
+++ b/tests/OK/inferingKindForArrowWithCodomainType.dk
@@ -1,0 +1,8 @@
+(; OK ;)
+
+A : Type.
+#INFER A -> Type.
+#PRINT "Kind".
+
+#INFER (A -> A) -> A -> Type.
+#PRINT "Kind".

--- a/tests/OK/inferingKindForType.dk
+++ b/tests/OK/inferingKindForType.dk
@@ -1,0 +1,4 @@
+(; OK ;)
+
+#INFER Type.
+#PRINT "Kind".


### PR DESCRIPTION
Hi all,

I wanted to fix the issue raised in #150 so I had a quick look at it. And as everybody probably guessed, the problem came from the fact that in env.ml, in order to infer the type of a term `t`, we call `Typing.infer` on `t` and obtain its type `ty`, and just after that we also check that the produced type `ty` is itself typable. That makes sense according to the LF typing rules, but only if the type obtained `ty` is not `Kind`, because `Kind` does not have a type itself (that's the end of the hierarchy in LF!), but that should not prevent `Type` to have type `Kind`.
So now, in Env.infer, we call Typing.infer, and **only if the result is not `Kind`** we infer a type for it as well (that we immediately throw away, as before).

The same thing had to be done in the (safe) reduction function from env.ml `_reduction` : we should only infer a type for the input `te` that we want to normalize if this input is not `Kind`, again because `Kind` does not have a type, but that should not prevent it from reducing (to itself, hopefully!).

I've also removed the test file KO/kind_typable_2.dk because it precisely tested that `#INFER Type` fails, which is no longer the case. I couldn't easily find a way to make this test accepted as an OK test, because we can't use `#INFER` for OK files (#INFER produces an output, which is not expected by the script file OK.sh). This script file should probably hope for a "SUCCESS" on the _last_ line, which would therefore allow to use `#INFER` in them. But I guess we don't really care because that's probably the only example where we would like to use #INFER on an OK file.
And obviously, we can't use `#ASSERT Type:Kind.` because we can't talk about `Kind` in the language.

Please, do not hesitate to tell me if you dislike something or disagree :)

Cheers,

Franck