### PR TITLE
Lazy rule addition into signature

### DIFF
--- a/kernel/rule.ml
+++ b/kernel/rule.ml
@@ -40,18 +40,19 @@ type constr =
   | Linearity of int * int
   | Bracket   of int * term
 
-type rule_infos = {
-  l           : loc;
-  name        : rule_name;
-  cst         : name;
-  args        : pattern list;
-  rhs         : term;
-  ctx_size    : int;
-  esize       : int;
-  pats        : wf_pattern array;
-  arity       : int array;
-  constraints : constr list;
-}
+type rule_infos =
+  {
+    l           : loc;
+    name        : rule_name;
+    cst         : name;
+    args        : pattern list;
+    rhs         : term;
+    ctx_size    : int;
+    esize       : int;
+    pats        : wf_pattern array;
+    arity       : int array;
+    constraints : constr list;
+  }
 
 let infer_rule_context ri =
   let res = Array.make ri.ctx_size (mk_ident "_") in

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -37,6 +37,13 @@ module HId = Hashtbl.Make(
     let hash  = Hashtbl.hash
   end )
 
+module HName = Hashtbl.Make(
+  struct
+    type t    = name
+    let equal = name_eq
+    let hash  = Hashtbl.hash
+  end )
+
 type staticity = Static | Definable
 
 (** The pretty printer for the type [staticity] *)
@@ -45,7 +52,6 @@ let pp_staticity fmt s =
 
 type symbol_infos =
   {
-    name  : name;
     stat  : staticity;
     ty    : term;
     rules : rule_infos list;
@@ -121,14 +127,14 @@ let unmarshal (lc:loc) (m:string) : string list * rw_infos HId.t * rule_infos li
   | _ -> raise (SignatureError (UnmarshalUnknown (lc,m)))
 
 let symbols_of sg =
-  HMd.fold (fun md ->
-      HId.fold (fun id (r:rw_infos) ->
-          List.cons
-            { name  = mk_name md id;
-              stat  = r.stat;
+  let table = HName.create 11 in
+  HMd.iter (fun md ->
+      HId.iter (fun id (r:rw_infos) ->
+          HName.add table (mk_name md id)
+            { stat  = r.stat;
               ty    = r.ty;
               rules =r.rules}))
-    sg.tables []
+    sg.tables; table
 
 
 

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -4,7 +4,6 @@ open Basic
 open Term
 open Rule
 
-
 type Debug.flag += D_module
 let _ = Debug.register_flag D_module "Module"
 

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -69,7 +69,12 @@ type t =
   {
     name   : mident;
     file   : string;
+    (** [tables] maps module ident to the hastable of their symbols.
+        It should only contain a single entry for each module.
+        Each module's hashtable should only contain a single entry
+        for each of its symbols. *)
     tables : (rw_infos HId.t) HMd.t;
+
     mutable external_rules:rule_infos list list;
   }
 

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -237,19 +237,19 @@ let is_static sg lc cst =
 
 let get_type sg lc cst = (get_infos sg lc cst).ty
 
+let get_rules sg lc cst = (get_infos sg lc cst).rules
+
 let get_dtree sg rule_filter l cst =
   match compute_dtree sg l cst, rule_filter with
-  | None       , _      -> Dtree.empty
-  | Some(trees), None   -> trees
-  | Some(trees), Some f ->
-     let rules = (get_infos sg l cst).rules in
+  | None      , _      -> Dtree.empty
+  | Some trees, None   -> trees
+  | Some trees, Some f ->
+     let rules = get_rules sg l cst in
      let rules' = List.filter (fun (r:Rule.rule_infos) -> f r.name) rules in
      if List.length rules' == List.length rules then trees
      else
        try Dtree.of_rules rules'
        with Dtree.DtreeError e -> raise (SignatureError (CannotBuildDtree e))
-
-let get_rules sg lc cst = (get_infos sg lc cst).rules
 
 (******************************************************************************)
 

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -212,7 +212,14 @@ let get_deps sg : string list = (*only direct dependencies*)
     ) sg.tables []
 
 let export sg =
-  if not (marshal sg.file (get_deps sg) (HMd.find sg.tables sg.name) sg.external_rules)
+  let mod_table = HMd.find sg.tables sg.name in
+  (* Making sure all decision trees are computed before exporting. *)
+  HId.iter
+    (fun id t ->
+       if not (snd t.decision_tree)
+       then ignore(compute_dtree sg dloc (mk_name sg.name id)))
+    mod_table;
+  if not (marshal sg.file (get_deps sg) mod_table sg.external_rules)
   then raise (SignatureError (CouldNotExportModule sg.file))
 
 (******************************************************************************)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -24,16 +24,6 @@ exception SignatureError of signature_error
 
 type staticity = Static | Definable
 
-type rw_infos =
-  {
-    stat          : staticity;
-    ty            : term;
-    rules         : rule_infos list;
-    decision_tree : Dtree.t option
-  }
-
-type symbol_infos = name * rw_infos
-
 type t
 
 val make                : string -> t
@@ -78,6 +68,14 @@ val add_declaration     : t -> loc -> ident -> staticity -> term -> unit
 val add_rules           : t -> Rule.rule_infos list -> unit
 (** [add_rules sg rule_lst] adds a list of rule to a symbol in the environement [sg].
     All rules must be on the same symbol. *)
+
+type symbol_infos =
+  {
+    name  : name;
+    stat  : staticity;
+    ty    : term;
+    rules : rule_infos list;
+  }
 
 val symbols_of : t ->  symbol_infos list
 (** [access_signature sg] returns the content of the signature [sg]. *)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -71,11 +71,12 @@ val add_rules           : t -> Rule.rule_infos list -> unit
 
 type symbol_infos =
   {
-    name  : name;
     stat  : staticity;
     ty    : term;
     rules : rule_infos list;
   }
 
-val symbols_of : t ->  symbol_infos list
+module HName : Hashtbl.S
+
+val symbols_of : t ->  symbol_infos HName.t
 (** [access_signature sg] returns the content of the signature [sg]. *)


### PR DESCRIPTION
Lazily adding new rules into signature without computing decision tree.
Decision tree is computed on demand, whenever it is required.