### PR TITLE
More elementary function in the APi

### DIFF
--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -417,10 +417,8 @@ let check_rule sg (rule:untyped_rule) : SS.t * typed_rule =
     rhs = rule.rhs
   }
 
-let typed_rule_of_rule_infos s ri =
-  let ur =
-    { name = ri.name
-    ; ctx  = infer_rule_context ri
-    ; pat  = pattern_of_rule_infos ri
-    ; rhs  = ri.rhs} in
-  check_rule s ur
+let untyped_rule_of_rule_infos s ri =
+  { name = ri.name
+  ; ctx  = infer_rule_context ri
+  ; pat  = pattern_of_rule_infos ri
+  ; rhs  = ri.rhs}

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -56,4 +56,4 @@ val inference   : Signature.t -> term -> typ
 val check_rule  : Signature.t -> untyped_rule -> Subst.Subst.t * typed_rule
 (** [check_rule sg ru] checks that a rule is well-typed. *)
 
-val typed_rule_of_rule_infos : Signature.t -> rule_infos -> Subst.Subst.t * typed_rule
+val untyped_rule_of_rule_infos : Signature.t -> rule_infos -> untyped_rule


### PR DESCRIPTION
Fraçois did not like to have in the API the function `typed_rule_of_rule_infos`since it was the composition of a function `untyped_rule_of_rule_infos`which was not accessible since inlined with `check_rule` which is in the API.
This PR separates the really new feature in the ad-hoc composition.