### PR TITLE
Flag to forbid non-left-linear rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ and a typical operation on vectors is concatenation:
 
 These rules verify the typing constraint given above: both left-hand and right-hand sides have the same type.
 
-Also, the second rule is non-left-linear; this is usually an issue because non-left-linear rewrite rules usually generate
+Also, the second rule is non-left-linear;
+this is usually an issue because in an untyped setting,
+non-left-linear rewrite rules usually generate
 a non-confluent rewrite system when combined with beta-reduction.
 
 However, because we only intend to rewrite *well-typed* terms, the rule above is computationally equivalent to the following left-linear rule:
@@ -250,11 +252,15 @@ the condition that the inferred types for these variables do not depend on the b
 
 #### NON-LEFT-LINEAR REWRITE RULES
 
-By default, `Dedukti` rejects non-left-linear rewrite rules because they usually generated non confluent rewrite systems
-when combined with beta-reduction. This behaviour can be changed by invoking `dkcheck` with the option `-nl`.
+By default, `Dedukti` accepts non-left-linear rewrite rules
+even though they usually generated non confluent rewrite systems
+when combined with beta-reduction.
 
     eq: Nat -> Nat -> Bool.
     [ n ] eq n n --> true.
+
+This behaviour can be changed by invoking `dkcheck` with the option `--ll` (left-linear)
+to guarantee that non-left-linear rewrite rules are never added to the system.
 
 #### HIGHER-ORDER REWRITE RULES
 

--- a/api/env.ml
+++ b/api/env.ml
@@ -23,7 +23,7 @@ type env_error =
   | EnvErrorType        of typing_error
   | EnvErrorSignature   of signature_error
   | EnvErrorRule        of rule_error
-  | NonLinearRule       of name
+  | NonLinearRule       of rule_name
   | NotEnoughArguments  of ident * int * int * int
   | KindLevelDefinition of ident
   | ParseError          of string
@@ -47,6 +47,8 @@ module R = Reduction.Default
 let sg = ref (Signature.make "noname")
 
 let check_arity = ref true
+
+let check_ll = ref false
 
 let init file =
   sg := Signature.make file;
@@ -114,9 +116,16 @@ let _check_arity (r:rule_infos) : unit =
   in
   aux 0 r.rhs
 
+(** Checks that all rule are left-linear. *)
+let _check_ll (r:rule_infos) : unit =
+  List.iter
+    (function Linearity _ -> raise (EnvError (r.l, NonLinearRule r.name)) | _ -> ())
+    r.constraints
+
 let _add_rules rs =
   let ris = List.map Rule.to_rule_infos rs in
   if !check_arity then List.iter _check_arity ris;
+  if !check_ll    then List.iter _check_ll    ris;
   Signature.add_rules !sg ris
 
 let _define lc (id:ident) (opaque:bool) (te:term) (ty_opt:typ option) : unit =

--- a/api/env.mli
+++ b/api/env.mli
@@ -9,7 +9,7 @@ type env_error =
   | EnvErrorType        of Typing.typing_error
   | EnvErrorSignature   of Signature.signature_error
   | EnvErrorRule        of Rule.rule_error
-  | NonLinearRule       of name
+  | NonLinearRule       of Rule.rule_name
   | NotEnoughArguments  of ident * int * int * int
   | KindLevelDefinition of ident
   | ParseError          of string
@@ -37,6 +37,9 @@ val set_debug_mode : string -> unit
 
 val check_arity : bool ref
 (** Flag to check for variables arity. Default is true. *)
+
+val check_ll : bool ref
+(** Flag to check for rules left linearity. Default is false. *)
 
 (** {2 The Global Environment} *)
 

--- a/api/errors.ml
+++ b/api/errors.ml
@@ -286,8 +286,8 @@ let fail_env_error lc err =
     fail lc
       "The variable '%a' is applied to %i argument(s) (expected: at least %i)."
       pp_ident id nb_args exp_nb_args
-  | Env.NonLinearRule (symb) ->
-    fail lc "Non left-linear rewrite rule for symbol '%a'." pp_name symb
+  | Env.NonLinearRule rule_name ->
+    fail lc "Non left-linear rewrite rule for symbol '%a'." Rule.pp_rule_name rule_name
   | Env.KindLevelDefinition id ->
     fail lc "Cannot add a rewrite rule for '%a' since it is a kind." pp_ident id
   | Env.ParseError s ->

--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -124,6 +124,9 @@ let _ =
       , " [EXPERIMENTAL] Allows the declaration of symbols whose type
                    contains Type in the left-hand side of a product
                    (Similar to the logic of the Calculus of Constructions)" )
+    ; ( "--ll"
+      , Arg.Set Env.check_ll
+      , " Checks left linearity of rules." )
     ; ( "--eta"
       , Arg.Tuple [Arg.Set Reduction.eta; Arg.Clear Env.check_arity]
       , " Allows the conversion test to use eta." )

--- a/tests/KO/nonleftlinear.dk
+++ b/tests/KO/nonleftlinear.dk
@@ -1,0 +1,5 @@
+(; KO 26 --ll ;)
+
+A : Type.
+eq : A -> A -> Type.
+[x] eq x x --> A.


### PR DESCRIPTION
Adds a new `--ll` flag to `dkcheck` checking that all rules are left-linear.
It's a property people usually want and it's nice to be able to check it, especially on generated files where the rewrite rules are huge and unreadable.

I believe there should even be more of these "disable advanced features" flags such as:
- "no brackets" to keep an efficient system.
- "no rewrite" to make sure no rewrite rule is added. This still allows for opaque definitions: `thm`. Probably useful in files supposed to only provided proofs and not extend the system.
- "no command"
- ...
but this is open for discussion.

These checks are not very useful but not very hard to implement either.