### PR TITLE
Extending the type preservation check

### DIFF
--- a/tests/OK/higher_order_cstr1.dk
+++ b/tests/OK/higher_order_cstr1.dk
@@ -1,0 +1,25 @@
+(; OK ;)
+
+N : Type.
+A : Type.
+T : A -> Type.
+
+P : (N -> A) -> Type.
+p : f : (N -> A) -> P f.
+
+g : (x : N) -> f : (N -> A) -> T (f x).
+def h : f : (N -> A) -> (x : N -> T (f x)) -> P (x => f x).
+
+(; The following rules are well-typed because
+
+we infer the constraint
+  (under 1 lambda)  X x[0] = Y x[0]
+
+and we need to deduce
+  P (x => X x) = P (x => Y x)
+;)
+
+[X,Y] h       Y    (z => g z       X   ) --> p (x => X x).
+[X,Y] h (y => Y y) (z => g z       X   ) --> p (x => X x).
+[X,Y] h       Y    (z => g z (x => X x)) --> p (x => X x).
+[X,Y] h (y => Y y) (z => g z (x => X x)) --> p (x => X x).

--- a/tests/OK/higher_order_cstr2.dk
+++ b/tests/OK/higher_order_cstr2.dk
@@ -1,0 +1,25 @@
+(; OK ;)
+
+N : Type.
+0 : N.
+
+A : Type.
+T : A -> Type.
+p : f : (N -> A) -> T (f 0).
+
+g : (x : N) -> f : (N -> A) -> T (f x).
+def h : f : (N -> A) -> (x : N -> T (f x)) -> T (f 0).
+
+(; The following rules are well-typed because
+
+we infer the constraint
+  (under 1 lambda)  X x[0] = Y x[0]
+
+and we need to deduce
+  T (X 0) = T (Y 0)
+;)
+
+[X,Y] h       Y    (z => g z       X   ) --> p X.
+[X,Y] h (y => Y y) (z => g z       X   ) --> p X.
+[X,Y] h       Y    (z => g z (x => X x)) --> p (x => X x).
+[X,Y] h (y => Y y) (z => g z (x => X x)) --> p (x => X x).


### PR DESCRIPTION
This is meant to be merged after #189 to better handle the several categories of inferred constraints.
In particular it seems reasonable to
- use 2)
- have a naive usage of 3) similar to the way Jui-Hsuan handles 4)

This PR is related to #183