### PR TITLE
Remove warning change the kernel as conform with PR #190

### DIFF
--- a/api/dep.ml
+++ b/api/dep.ml
@@ -1,6 +1,6 @@
 open Kernel
 open Basic
-open Parsing
+open Parsers
 
 type path = string
 
@@ -62,7 +62,14 @@ let find_dk : mident -> path list -> path option = fun md path ->
   | fs  ->
     raise @@ Dep_error(MultipleModules(name,fs))
 
-let get_file md =
+
+let path = ref []
+
+let get_path () = !path
+
+let add_path s = path := s :: !path
+
+let get_file _ md =
   match find_dk md (get_path ()) with
   | None -> raise @@ Dep_error(ModuleNotFound md)
   | Some f -> f
@@ -172,13 +179,13 @@ let initialize : mident -> path -> unit = fun md file ->
   current_deps := {!current_deps with file}
 
 let make : mident -> Entry.entry list -> unit = fun md entries ->
-  let file = get_file md in
+  let file = get_file Basic.dloc md in
   initialize md file;
   List.iter handle_entry entries;
   Hashtbl.replace deps md !current_deps
 
 let handle : mident -> ((Entry.entry -> unit) -> unit) -> unit = fun md process ->
-  let file = get_file md in
+  let file = get_file Basic.dloc md in
   initialize md file;
   process handle_entry;
   Hashtbl.replace deps md !current_deps

--- a/api/dep.mli
+++ b/api/dep.mli
@@ -1,5 +1,5 @@
 open Kernel
-open Parsing
+open Parsers
 
 exception Dep_error of Entry.dep_error
 
@@ -28,11 +28,18 @@ val deps : t
 
 val ignore : bool ref
 
+val add_path : string -> unit
+(** [add_path p] add the [p] to the load path *)
+
+val get_path : unit -> string list
+(** [get_path ()] returns all the paths in the load path *)
+
+
 val compute_ideps : bool ref
 (** Whether to compute dependencies of every element.  If set to
     [false], only module dependencies are computed. *)
 
-val get_file : Basic.mident -> path
+val get_file : Basic.loc -> Basic.mident -> path
 (** [get_file md] returns the path associated to module [md] *)
 
 val get_data : Basic.name -> data

--- a/api/dune
+++ b/api/dune
@@ -1,4 +1,4 @@
 (library
     (name api)
     (public_name dedukti.api)
-    (libraries kernel parsing))
+    (libraries kernel parsers))

--- a/api/env.mli
+++ b/api/env.mli
@@ -3,7 +3,7 @@
 open Kernel
 open Basic
 open Term
-open Parsing
+open Parsers
 
 (** {2 Debugging} *)
 

--- a/api/pp.ml
+++ b/api/pp.ml
@@ -2,9 +2,8 @@ open Kernel
 open Basic
 open Term
 open Rule
-open Parsing
+open Parsers
 open Format
-open Entry
 
 (* FIXME: this module is highly redondant with printing functions insides kernel modules *)
 
@@ -245,6 +244,7 @@ let print_red_cfg fmt cfg =
 
 let print_entry fmt e =
   let open Format in
+  let open Entry in
   match e with
   | Decl(_,id,Signature.Static,ty) ->
     fprintf fmt "@[<2>%a :@ %a.@]@.@." print_ident id print_term ty

--- a/api/pp.mli
+++ b/api/pp.mli
@@ -34,7 +34,7 @@ sig
   val print_rule_infos    : Rule.rule_infos     printer
   val print_rule_name     : Rule.rule_name      printer
   val print_red_cfg       : Reduction.red_cfg   printer
-  val print_entry         : Parsing.Entry.entry   printer
+  val print_entry         : Parsers.Entry.entry printer
   val print_staticity     : Signature.staticity printer
 end
 

--- a/api/processor.ml
+++ b/api/processor.ml
@@ -1,6 +1,6 @@
 open Kernel
 open Basic
-open Parsing
+open Parsers
 
 module type S =
 sig

--- a/api/processor.mli
+++ b/api/processor.mli
@@ -3,7 +3,7 @@ module type S =
 sig
   type t
 
-  val handle_entry : Parsing.Entry.entry -> unit
+  val handle_entry : Parsers.Entry.entry -> unit
 
   val get_data : unit -> t
 end

--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -1,5 +1,5 @@
 open Kernel
-open Parsing
+open Parsers
 open Api
 
 open Basic
@@ -45,7 +45,7 @@ let _ =
       , Arg.Set export
       , " Generates an object file (\".dko\")" )
     ; ( "-I"
-      , Arg.String Basic.add_path
+      , Arg.String Dep.add_path
       , "DIR Adds the directory DIR to the load path" )
     ; ( "-d"
       , Arg.String Env.set_debug_mode

--- a/commands/dkdep.ml
+++ b/commands/dkdep.ml
@@ -1,5 +1,5 @@
 open Kernel
-open Parsing
+open Parsers
 open Api
 
 open Basic
@@ -72,7 +72,7 @@ let _ =
       , Arg.Set Dep.ignore
       , " If some dependencies are not found, ignore them" )
     ; ( "-I"
-      , Arg.String add_path
+      , Arg.String Dep.add_path
       , "DIR Add the directory DIR to the load path" ) ]
   in
   let usage = Format.sprintf "Usage: %s [OPTION]... [FILE]...

--- a/commands/dkprune.ml
+++ b/commands/dkprune.ml
@@ -1,5 +1,5 @@
 open Kernel
-open Parsing
+open Parsers
 open Api
 
 open Basic
@@ -61,14 +61,14 @@ let rec handle_file : string -> unit =
         let md_deps = Hashtbl.find Dep.deps md in
         Dep.MDepSet.iter
           (fun (md,_) ->
-            try handle_file (Dep.get_file md)
+            try handle_file (Dep.get_file Basic.dloc md)
             with _ -> ())
           Dep.(md_deps.deps)
       end
 
 let handle_name : Basic.name -> unit = fun name ->
   let md = Basic.md name in
-  let file = Dep.get_file md in
+  let file = Dep.get_file Basic.dloc md in
   handle_file file
 
 let handle_constraints names =
@@ -83,7 +83,7 @@ let output_file : Dep.path -> Dep.path = fun file ->
 let get_files : unit -> (mident * Dep.path * Dep.path) list = fun () ->
   Hashtbl.fold (fun md _ l ->
       try
-        let f = Dep.get_file md in
+        let f = Dep.get_file Basic.dloc md in
         (md, f, output_file f)::l
     with _ -> l) Dep.deps []
 
@@ -138,7 +138,7 @@ let print_dependencies names =
 
 (* This opens a module and returns all the names of symbols declared inside *)
 let names_of_md md =
-  let file = Dep.get_file md in
+  let file = Dep.get_file Basic.dloc md in
   let input = open_in file in
   let names = ref Dep.NameSet.empty in
   let mk_entry e =
@@ -169,7 +169,7 @@ let _ =
       , Arg.Unit enable_log
       , " Print log")
     ; ( "-I"
-      , Arg.String add_path
+      , Arg.String Dep.add_path
       , " DIR Add the directory DIR to the load path" )
     ; ( "-o"
       , Arg.String (fun s -> output_directory := Some s)

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -1,5 +1,5 @@
 open Kernel
-open Parsing
+open Parsers
 open Api
 
 open Basic

--- a/commands/dune
+++ b/commands/dune
@@ -2,22 +2,22 @@
     (name dkcheck)
     (public_name dkcheck)
     (modules dkcheck)
-    (libraries kernel parsing api))
+    (libraries kernel parsers api))
 
 (executable
     (name dkdep)
     (public_name dkdep)
     (modules dkdep)
-    (libraries kernel parsing api))
+    (libraries kernel parsers api))
 
 (executable
     (name dktop)
     (public_name dktop)
     (modules dktop)
-    (libraries kernel parsing api))
+    (libraries kernel parsers api))
 
 (executable
     (name dkprune)
     (public_name dkprune)
     (modules dkprune)
-    (libraries kernel parsing api))
+    (libraries kernel parsers api))

--- a/kernel/basic.ml
+++ b/kernel/basic.ml
@@ -31,17 +31,20 @@ struct
   let hash      = Hashtbl.hash
 end )
 
-let shash        = WS.create 251
+let hash_ident   = WS.create 251
 
-let mk_ident     = WS.merge shash
+let mk_ident     = WS.merge hash_ident
 
-let mk_mident md =
-  let base = Filename.basename md in
-  if Filename.check_suffix base ".dk"
-  then Filename.chop_suffix base ".dk"
-  else base
+let hash_mident  = WS.create 251
+
+let mk_mident md = WS.merge hash_mident md
 
 let dmark       = mk_ident "$"
+
+module IdentSet  = Set.Make(struct type t = ident  let compare = compare end)
+module MidentSet = Set.Make(struct type t = mident let compare = compare end)
+module NameSet   = Set.Make(struct type t = name   let compare = compare end)
+
 
 (** {2 Lists with Length} *)
 
@@ -66,10 +69,6 @@ type loc = int * int
 let dloc = (-1,-1)
 let mk_loc l c = (l,c)
 let of_loc l = l
-
-let path = ref []
-let get_path () = !path
-let add_path s = path := s :: !path
 
 (** {2 Debugging} *)
 

--- a/kernel/basic.mli
+++ b/kernel/basic.mli
@@ -47,6 +47,12 @@ val dmark : ident
 
 (** The kernel may introduce such identifiers when creating new de Bruijn indices *)
 
+module MidentSet : Set.S with type elt = mident
+
+module IdentSet : Set.S with type elt = mident
+
+module NameSet : Set.S with type elt = name
+
 
 (** {2 Lists with Length} *)
 (** A list where the method len is O(1). It is used by {!Matching}. *)
@@ -72,14 +78,11 @@ type loc
 val dloc : loc
 (** a dummy location *)
 
-val mk_loc : int -> int -> loc
 (** [mk_loc l c] builds the location where [l] is the line and [c] the column *)
+val mk_loc : int -> int -> loc
 
-val of_loc : loc -> int * int
 (** [of_loc l] returns the line and the column associated to the position*)
-
-val add_path : string -> unit
-val get_path : unit -> string list
+val of_loc : loc -> int * int
 
 (** {2 Debug} *)
 

--- a/kernel/dtree.ml
+++ b/kernel/dtree.ml
@@ -10,7 +10,7 @@ type dtree_error =
   | HeadSymbolMismatch  of loc * name * name
   | ArityInnerMismatch  of loc * ident * ident
 
-exception DtreeError of dtree_error
+exception Dtree_error of dtree_error
 
 type case =
   | CConst of int * name
@@ -136,7 +136,7 @@ let specialize_rule (c:int) (nargs:int) (r:rule_infos) : rule_infos =
     else (* size <= i < size+nargs *)
       let check_args id pats =
         if ( Array.length pats != nargs ) then
-          raise (DtreeError(ArityInnerMismatch(r.l, Basic.id r.cst, id)));
+          raise (Dtree_error(ArityInnerMismatch(r.l, Basic.id r.cst, id)));
         pats.( i - size)
       in
       match r.pats.(c) with
@@ -268,7 +268,7 @@ let of_rules = function
     List.iter
       (fun x ->
          if not (name_eq x.cst name)
-         then raise (DtreeError (HeadSymbolMismatch (x.l,x.cst,name)));
+         then raise (Dtree_error (HeadSymbolMismatch (x.l,x.cst,name)));
          let arity = List.length x.args in
          arities := add !arities arity)
       rs;

--- a/kernel/dtree.mli
+++ b/kernel/dtree.mli
@@ -9,7 +9,7 @@ type dtree_error =
   | HeadSymbolMismatch  of loc * name * name
   | ArityInnerMismatch  of loc * ident * ident
 
-exception DtreeError of dtree_error
+exception Dtree_error of dtree_error
 
 (** {2 Decision Trees} *)
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -141,7 +141,7 @@ and test (rn:Rule.rule_name) (sg:Signature.t)
      let t2 = term_of_state { ctx; term=t; stack=[] } in
      if C.matching_test (Bracket (i,t)) rn sg t1 t2
      then test rn sg ctx tl
-     else raise (Signature.SignatureError(Signature.GuardNotSatisfied(get_loc t1, t1, t2)))
+     else raise (Signature.Signature_error(Signature.GuardNotSatisfied(get_loc t1, t1, t2)))
 
 and find_case (st:state) (cases:(case*dtree) list)
     (default:dtree option) : (dtree * stack) option =

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -46,6 +46,9 @@ exception NotConvertible
 val eta : bool ref
 (** Set to [true] to allow eta expansion at conversion check *)
 
+val selection : (Rule.rule_name -> bool) option ref
+(** This predicate restrict the rules which can be used by the rewrite engine. Default is None meaning that every rules in Signature are used *)
+
 module type ConvChecker = sig
   val are_convertible  : convertibility_test
   (** [are_convertible sg t1 t2] checks whether [t1] and [t2] are convertible

--- a/kernel/rule.mli
+++ b/kernel/rule.mli
@@ -61,14 +61,16 @@ type typed_rule = typed_context rule
 (** {2 Errors} *)
 
 type rule_error =
-  | BoundVariableExpected          of pattern
+  | BoundVariableExpected          of loc * pattern
   | DistinctBoundVariablesExpected of loc * ident
-  | VariableBoundOutsideTheGuard   of term
+  | VariableBoundOutsideTheGuard   of loc * term
   | UnboundVariable                of loc * ident * pattern
   | AVariableIsNotAPattern         of loc * ident
   | NonLinearNonEqArguments        of loc * ident
+  | NotEnoughArguments             of loc * ident * int * int * int
+  | NonLinearRule                  of loc * rule_name
 
-exception RuleError of rule_error
+exception Rule_error of rule_error
 
 (** {2 Rule infos} *)
 
@@ -114,3 +116,7 @@ val pp_typed_context   : typed_context   printer
 val pp_rule_infos      : rule_infos      printer
 
 val untyped_rule_of_rule_infos : rule_infos -> untyped_rule
+
+val check_arity : rule_infos -> unit
+
+val check_linearity : rule_infos -> unit

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -7,6 +7,8 @@ open Rule
 type Debug.flag += D_module
 let _ = Debug.register_flag D_module "Module"
 
+type file = string
+
 let fail_on_symbol_not_found = ref true
 
 type signature_error =
@@ -21,9 +23,9 @@ type signature_error =
   | ConfluenceErrorImport of loc * mident * Confluence.confluence_error
   | ConfluenceErrorRules  of loc * rule_infos list * Confluence.confluence_error
   | GuardNotSatisfied     of loc * term * term
-  | CouldNotExportModule  of mident * string
+  | CannotExportModule    of mident * exn
 
-exception SignatureError of signature_error
+exception Signature_error of signature_error
 
 module HMd = Hashtbl.Make(
   struct
@@ -42,8 +44,8 @@ module HId = Hashtbl.Make(
 type staticity = Static | Definable
 
 (** The pretty printer for the type [staticity] *)
-let pp_staticity fmt s =
-  Format.fprintf fmt "%s" (if s=Static then "Static" else "Definable")
+(* let pp_staticity fmt s =
+ *   Format.fprintf fmt "%s" (if s=Static then "Static" else "Definable") *)
 
 type rw_infos =
   {
@@ -55,8 +57,7 @@ type rw_infos =
 
 type t =
   {
-    name   : mident;
-    file   : string;
+    md     : mident;
     (** [tables] maps module ident to the hastable of their symbols.
         It should only contain a single entry for each module.
         Each module's hashtable should only contain a single entry
@@ -64,69 +65,48 @@ type t =
     tables : (rw_infos HId.t) HMd.t;
 
     mutable external_rules:rule_infos list list;
+
+    get_file : loc -> mident -> string
   }
 
-let make file =
-  let name = mk_mident file in
+let make md get_file =
   let tables = HMd.create 19 in
-  HMd.replace tables name (HId.create 251);
-  { name; file; tables; external_rules=[]; }
+  HMd.replace tables md (HId.create 251);
+  { md; tables; external_rules=[]; get_file}
 
-let get_name sg = sg.name
+let get_name sg = sg.md
 
 (******************************************************************************)
 
-let marshal (file:string) (deps:string list) (env:rw_infos HId.t) (ext:rule_infos list list) : bool =
+let marshal : mident -> mident list -> rw_infos HId.t -> rule_infos list list -> out_channel -> unit =
+  fun md deps env ext oc ->
   try
-    let file = (try Filename.chop_extension file with _ -> file) ^ ".dko" in
-    let oc = open_out file in
     Marshal.to_channel oc Version.version [];
     Marshal.to_channel oc deps [];
     Marshal.to_channel oc env [];
     Marshal.to_channel oc ext [];
-    close_out oc; true
-  with _ -> false
+    close_out oc
+  with e -> raise @@ Signature_error (CannotExportModule(md,e))
 
-let file_exists = Sys.file_exists
-
-let rec find_dko_in_path name = function
-  | [] -> failwith "find_dko"  (* Captured by the unmarshal function *)
-  | dir :: path ->
-      let filename = dir ^ "/" ^ name ^ ".dko" in
-      if file_exists filename
-      then open_in filename
-      else find_dko_in_path name path
-
-let find_dko name =
-  let filename = name ^ ".dko" in
-  if file_exists filename (* First check in the current directory *)
-  then open_in filename
-  else find_dko_in_path name (get_path())
-  (* If not found in the current directory, search in load-path *)
-
-let unmarshal (lc:loc) (m:string) : string list * rw_infos HId.t * rule_infos list list =
+let unmarshal (lc:loc) (file:string) : mident list * rw_infos HId.t * rule_infos list list =
   try
-    let chan = find_dko m in
-    let ver:string = Marshal.from_channel chan in
+    let ic = open_in file in
+    let ver:string = Marshal.from_channel ic in
     if String.compare ver Version.version <> 0
-    then raise (SignatureError (UnmarshalBadVersionNumber (lc,m)));
-    let deps:string list         = Marshal.from_channel chan in
-    let ctx:rw_infos HId.t       = Marshal.from_channel chan in
-    let ext:rule_infos list list = Marshal.from_channel chan in
-    close_in chan; (deps,ctx,ext)
+    then raise (Signature_error (UnmarshalBadVersionNumber (lc,file)));
+    let deps:mident list         = Marshal.from_channel ic in
+    let ctx:rw_infos HId.t       = Marshal.from_channel ic in
+    let ext:rule_infos list list = Marshal.from_channel ic in
+    close_in ic; (deps,ctx,ext)
   with
-  | Sys_error s -> raise (SignatureError (UnmarshalSysError (lc,m,s)))
-  | SignatureError s -> raise (SignatureError s)
-  | _ -> raise (SignatureError (UnmarshalUnknown (lc,m)))
-
+  | Sys_error s -> raise (Signature_error (UnmarshalSysError (lc,file,s)))
+  | Signature_error s -> raise (Signature_error s)
 
 let fold_symbols f sg =
   HMd.fold (fun md table t -> HId.fold (f md) table t) sg.tables
 
 let iter_symbols f sg =
   fold_symbols (fun md id rw () -> f md id rw) sg ()
-
-
 
 (******************************************************************************)
 
@@ -140,13 +120,13 @@ let check_confluence_on_import lc (md:mident) (ctx:rw_infos HId.t) : unit =
   Debug.debug Confluence.D_confluence
     "Checking confluence after loading module '%a'..." pp_mident md;
   try Confluence.check () with
-  | Confluence.ConfluenceError e -> raise (SignatureError (ConfluenceErrorImport (lc,md,e)))
+  | Confluence.ConfluenceError e -> raise (Signature_error (ConfluenceErrorImport (lc,md,e)))
 
 let add_external_declaration sg lc cst st ty =
   try
     let env = HMd.find sg.tables (md cst) in
     if HId.mem env (id cst)
-    then raise (SignatureError (AlreadyDefinedSymbol (lc, cst)))
+    then raise (Signature_error (AlreadyDefinedSymbol (lc, cst)))
     else HId.replace env (id cst) {stat=st; ty=ty; rules=[]; decision_tree=None}
   with Not_found ->
     HMd.replace sg.tables (md cst) (HId.create 11);
@@ -154,19 +134,18 @@ let add_external_declaration sg lc cst st ty =
     HId.replace env (id cst) {stat=st; ty=ty; rules=[]; decision_tree=None}
 
 (* Recursively load a module and its dependencies*)
-let rec import sg lc m =
-  if HMd.mem sg.tables m
-  then Debug.(debug D_warn "Trying to import the already loaded module %s." (string_of_mident m))
+let rec import sg lc md =
+  if HMd.mem sg.tables md
+  then Debug.(debug D_warn "Trying to import the already loaded module %s." (string_of_mident md))
   else
-    let (deps,ctx,ext) = unmarshal lc (string_of_mident m) in
-    HMd.replace sg.tables m ctx;
-    List.iter ( fun dep0 ->
-        let dep = mk_mident dep0 in
+    let (deps,ctx,ext) = unmarshal lc (sg.get_file lc md) in
+    HMd.replace sg.tables md ctx;
+    List.iter ( fun dep ->
         if not (HMd.mem sg.tables dep) then import sg lc dep
       ) deps ;
-    Debug.(debug D_module "Loading module '%a'..." pp_mident m);
+    Debug.(debug D_module "Loading module '%a'..." pp_mident md);
     List.iter (fun rs -> add_rule_infos sg rs) ext;
-    check_confluence_on_import lc m ctx
+    check_confluence_on_import lc md ctx
 
 and add_rule_infos sg (lst:rule_infos list) : unit =
   match lst with
@@ -175,13 +154,13 @@ and add_rule_infos sg (lst:rule_infos list) : unit =
     let infos, env =
       try get_info_env sg r.l r.cst
       with
-      | SignatureError (SymbolNotFound _)
-      | SignatureError (UnmarshalUnknown _) when not !fail_on_symbol_not_found ->
+      | Signature_error (SymbolNotFound _)
+      | Signature_error (UnmarshalUnknown _) when not !fail_on_symbol_not_found ->
         add_external_declaration sg r.l r.cst Definable (mk_Kind);
         get_info_env sg r.l r.cst
     in
     if infos.stat = Static && !fail_on_symbol_not_found
-    then raise (SignatureError (CannotAddRewriteRules (r.l,r.cst)));
+    then raise (Signature_error (CannotAddRewriteRules (r.l,r.cst)));
     HId.replace env (id r.cst) {infos with rules = infos.rules @ rs; decision_tree= None}
 
 and compute_dtree sg (lc:Basic.loc) (cst:Basic.name) : Dtree.t option =
@@ -191,7 +170,7 @@ and compute_dtree sg (lc:Basic.loc) (cst:Basic.name) : Dtree.t option =
   | None, (_::_ as rules) ->
     let trees =
       try Dtree.of_rules rules
-      with Dtree.DtreeError e -> raise (SignatureError (CannotBuildDtree e))
+      with Dtree.Dtree_error e -> raise (Signature_error (CannotBuildDtree e))
     in
     HId.replace env (id cst) {infos with decision_tree=Some trees};
     Some trees
@@ -204,21 +183,17 @@ and get_info_env sg lc cst =
     with Not_found -> import sg lc md; HMd.find sg.tables md
   in
   try (HId.find env (id cst), env)
-  with Not_found -> raise (SignatureError (SymbolNotFound (lc,cst)))
+  with Not_found -> raise (Signature_error (SymbolNotFound (lc,cst)))
 
 and get_infos sg lc cst = fst (get_info_env sg lc cst)
 
 (******************************************************************************)
 
-let get_md_deps (lc:loc) (md:mident) =
-  let (deps,_,_) = unmarshal lc (string_of_mident md) in
-  List.map mk_mident deps
-
-let get_deps sg : string list = (*only direct dependencies*)
+let get_deps sg : mident list = (*only direct dependencies*)
   HMd.fold (
     fun md _ lst ->
-      if mident_eq md sg.name then lst
-      else (string_of_mident md)::lst
+      if mident_eq md sg.md then lst
+      else md::lst
     ) sg.tables []
 
 
@@ -228,10 +203,10 @@ let import_signature sg sg_ext =
         HMd.replace sg.tables m (HId.copy hid)) sg_ext.tables;
   List.iter (fun rs -> add_rule_infos sg rs) sg_ext.external_rules
 
-let export sg =
-  let mod_table = HMd.find sg.tables sg.name in
-  if not (marshal sg.file (get_deps sg) mod_table sg.external_rules)
-  then raise (SignatureError (CouldNotExportModule (sg.name, sg.file)))
+let export sg oc =
+  let mod_table = HMd.find sg.tables sg.md in
+  marshal sg.md (get_deps sg) mod_table sg.external_rules oc
+
 
 (******************************************************************************)
 
@@ -255,7 +230,7 @@ let get_dtree sg lc cst =
 (******************************************************************************)
 
 let add_declaration sg lc v st ty =
-  let cst = mk_name sg.name v in
+  let cst = mk_name sg.md v in
   add_external_declaration sg lc cst st ty
 
 let add_rules sg = function
@@ -263,12 +238,12 @@ let add_rules sg = function
   | r :: _ as rs ->
     try
       add_rule_infos sg rs;
-      if not (mident_eq sg.name (md r.cst)) then
+      if not (mident_eq sg.md (md r.cst)) then
         sg.external_rules <- rs::sg.external_rules;
       Confluence.add_rules rs;
       Debug.(debug Confluence.D_confluence
                "Checking confluence after adding rewrite rules on symbol '%a'"
                pp_name r.cst);
       try Confluence.check ()
-      with Confluence.ConfluenceError e -> raise (SignatureError (ConfluenceErrorRules (r.l,rs,e)))
-    with RuleError e -> raise (SignatureError (CannotMakeRuleInfos e))
+      with Confluence.ConfluenceError e -> raise (Signature_error (ConfluenceErrorRules (r.l,rs,e)))
+    with Rule_error e -> raise (Signature_error (CannotMakeRuleInfos e))

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -6,10 +6,12 @@ open Rule
 
 type Debug.flag += D_module
 
+type file = string
+
 type signature_error =
-  | UnmarshalBadVersionNumber of loc * string
-  | UnmarshalSysError     of loc * string * string
-  | UnmarshalUnknown      of loc * string
+  | UnmarshalBadVersionNumber of loc * file
+  | UnmarshalSysError     of loc * file * string
+  | UnmarshalUnknown      of loc * file
   | SymbolNotFound        of loc * name
   | AlreadyDefinedSymbol  of loc * name
   | CannotMakeRuleInfos   of Rule.rule_error
@@ -18,34 +20,28 @@ type signature_error =
   | ConfluenceErrorImport of loc * mident * Confluence.confluence_error
   | ConfluenceErrorRules  of loc * rule_infos list * Confluence.confluence_error
   | GuardNotSatisfied     of loc * term * term
-  | CouldNotExportModule  of mident * string
+  | CannotExportModule    of mident * exn
 
-exception SignatureError of signature_error
+exception Signature_error of signature_error
 
 type staticity = Static | Definable
 
-val pp_staticity : staticity printer
-
 type t
 
-val make                : string -> t
+val make                : mident -> (loc -> mident -> file) -> t
 (** [make file] creates a new signature corresponding to the file [file]. *)
 
 val get_name            : t -> mident
 (** [get_name sg] returns the name of the signature [sg]. *)
 
-val export              : t -> unit
-(** [export ()] saves the current environment in a [*.dko] file.*)
+val export              : t -> out_channel -> unit
+(** [export sg oc] saves the current environment in [oc] file.*)
 
 val import              : t -> loc -> mident -> unit
 (** [import sg md] impots the module [md] in the signature [sg]. *)
 
 val import_signature    : t -> t -> unit
 (** [import sg sg_ext] imports the signature [sg_ext] into the signature [sg]. *)
-
-val get_md_deps            : loc -> mident -> mident list
-(** [get_deps lc md] returns the list of direct dependencies of module [md].
-    This function makes the assumption that the file [md.dko] exists. *)
 
 val is_static           : t -> loc -> name -> bool
 (** [is_injective sg l cst] is true when [cst] is a static symbol. *)
@@ -61,11 +57,11 @@ val get_dtree           : t -> loc -> name -> Dtree.t
 val get_rules           : t -> loc -> name -> rule_infos list
 (** [get_rules sg lc cst] returns a list of rules that defines the symbol. *)
 
-val add_declaration     : t -> loc -> ident -> staticity -> term -> unit
-(** [add_declaration sg l id st ty] declares the symbol [id] of type [ty]
-    and staticity [st] in the environment [sg]. *)
+val add_external_declaration     : t -> loc -> name -> staticity -> term -> unit
+(** [add_external_declaration sg l cst st ty] declares the symbol [id] of type
+    [ty] and staticity [st] in the environment [sg]. *)
 
-val add_external_declaration : t -> loc -> name -> staticity -> term -> unit
+val add_declaration     : t -> loc -> ident -> staticity -> term -> unit
 (** [add_declaration sg l id st ty] declares the symbol [id] of type [ty]
     and staticity [st] in the environment [sg]. *)
 
@@ -80,7 +76,6 @@ val fail_on_symbol_not_found : bool ref
        in the signature. However, a fresh symbol is added.
     This flag is intented to facilitate the use of the module Reduction
     when it is used without the module Typing such as in dkmeta. *)
-
 
 type rw_infos =
   {

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -35,7 +35,7 @@ type typing_error =
   | Convertible                        of loc * term * term
   | Inhabit                            of loc * term * term
 
-exception TypingError of typing_error
+exception Typing_error of typing_error
 
 module type S = sig
   val infer       : Signature.t -> typed_context -> term -> typ
@@ -55,21 +55,21 @@ struct
 
   let get_type ctx l x n =
     try let (_,_,ty) = List.nth ctx n in Subst.shift (n+1) ty
-    with Failure _ -> raise (TypingError (VariableNotFound (l,x,n,ctx)))
+    with Failure _ -> raise (Typing_error (VariableNotFound (l,x,n,ctx)))
 
   let extend_ctx a ctx = function
     | Type _ -> a::ctx
     | Kind when !coc -> a::ctx
     | ty_a ->
       let (_,_,te) = a in
-      raise (TypingError (ConvertibilityError (te, ctx, mk_Type dloc, ty_a)))
+      raise (Typing_error (ConvertibilityError (te, ctx, mk_Type dloc, ty_a)))
 
   (* ********************** TYPE CHECKING/INFERENCE FOR TERMS  *)
 
   let rec infer sg (ctx:typed_context) (te:term) : typ =
     Debug.(debug D_typeChecking "Inferring: %a" pp_term te);
     match te with
-    | Kind -> raise (TypingError KindIsNotTypable)
+    | Kind -> raise (Typing_error KindIsNotTypable)
     | Type _ -> mk_Kind
     | DB (l,x,n) -> get_type ctx l x n
     | Const (l,cst) -> Signature.get_type sg l cst
@@ -81,15 +81,15 @@ struct
       let ty_b = infer sg ctx2 b in
       ( match ty_b with
         | Kind | Type _ -> ty_b
-        | _ -> raise (TypingError (SortExpected (b, ctx2, ty_b))) )
+        | _ -> raise (Typing_error (SortExpected (b, ctx2, ty_b))) )
     | Lam  (l,x,Some a,b) ->
       let ty_a = infer sg ctx a in
       let ctx2 = extend_ctx (l,x,a) ctx ty_a in
       let ty_b = infer sg ctx2 b in
       ( match ty_b with
-        | Kind -> raise (TypingError (InexpectedKind (b, ctx2)))
+        | Kind -> raise (Typing_error (InexpectedKind (b, ctx2)))
         | _ -> mk_Pi l x a ty_b )
-    | Lam  (l,_,None,_) -> raise (TypingError (DomainFreeLambda l))
+    | Lam  (l,_,None,_) -> raise (Typing_error (DomainFreeLambda l))
 
   and check sg (ctx:typed_context) (te:term) (ty_exp:typ) : unit =
     Debug.(debug D_typeChecking "Checking (%a): %a : %a" pp_loc (get_loc te) pp_term te pp_term ty_exp);
@@ -98,7 +98,7 @@ struct
       begin
         match R.whnf sg ty_exp with
         | Pi (_,_,a,ty_b) -> check sg ((l,x,a)::ctx) b ty_b
-        | _ -> raise (TypingError (ProductExpected (te,ctx,ty_exp)))
+        | _ -> raise (Typing_error (ProductExpected (te,ctx,ty_exp)))
       end
     | Lam (l,x,Some a,b) ->
       begin
@@ -106,9 +106,9 @@ struct
         | Pi (_,_,a',ty_b) ->
           ignore(infer sg ctx a);
           if not (R.are_convertible sg a a')
-          then raise (TypingError (ConvertibilityError ((mk_DB l x 0),ctx,a',a)))
+          then raise (Typing_error (ConvertibilityError ((mk_DB l x 0),ctx,a',a)))
           else check sg ((l,x,a)::ctx) b ty_b
-        | _ -> raise (TypingError (ProductExpected (te,ctx,ty_exp)))
+        | _ -> raise (Typing_error (ProductExpected (te,ctx,ty_exp)))
       end
     | _ ->
       let ty_inf = infer sg ctx te in
@@ -116,13 +116,13 @@ struct
                pp_term ty_inf pp_term ty_exp);
       if not (R.are_convertible sg ty_inf ty_exp) then
         let ty_exp' = rename_vars_with_typed_context ctx ty_exp in
-        raise (TypingError (ConvertibilityError (te,ctx,ty_exp',ty_inf)))
+        raise (Typing_error (ConvertibilityError (te,ctx,ty_exp',ty_inf)))
 
   and check_app sg (ctx:typed_context) (f,ty_f:term*typ) (arg:term) : term*typ =
     match R.whnf sg ty_f with
     | Pi (_,_,a,b) ->
       let _ = check sg ctx arg a in (mk_App f arg [], Subst.subst b arg )
-    | _ -> raise (TypingError ( ProductExpected (f,ctx,ty_f)))
+    | _ -> raise (Typing_error ( ProductExpected (f,ctx,ty_f)))
 
   let inference sg (te:term) : typ = infer sg [] te
 
@@ -302,7 +302,7 @@ let rec infer_pattern sg (delta:partial_context) (sigma:context2)
     in (ty,delta2,lst2)
   | Var _ | Brackets _ | Lambda _ ->
     let ctx = (LList.lst sigma)@(pc_to_context_wp delta) in
-    raise (TypingError (CannotInferTypeOfPattern (pat,ctx)))
+    raise (Typing_error (CannotInferTypeOfPattern (pat,ctx)))
 
 and infer_pattern_aux sg
     (sigma,f,ty_f,delta,lst : context2*term*typ*partial_context*constraints)
@@ -314,7 +314,7 @@ and infer_pattern_aux sg
     ( sigma, Term.mk_App f arg' [], Subst.subst b arg', delta2 , lst2 )
   | ty_f ->
     let ctx = (LList.lst sigma)@(pc_to_context_wp delta) in
-    raise (TypingError (ProductExpected (f,ctx,ty_f)))
+    raise (Typing_error (ProductExpected (f,ctx,ty_f)))
 
 and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
     (lst:constraints) (pat:pattern) : partial_context * constraints =
@@ -325,22 +325,22 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
     begin
       match R.whnf sg exp_ty with
       | Pi (_,_,a,b) -> check_pattern sg delta (LList.cons (l,x,a) sigma) b lst p
-      | _            -> raise (TypingError ( ProductExpected (pattern_to_term pat,ctx (),exp_ty)))
+      | _ -> raise (Typing_error ( ProductExpected (pattern_to_term pat,ctx (),exp_ty)))
     end
   | Brackets te ->
     let _ =
       try Subst.unshift (LList.len sigma) te
-      with Subst.UnshiftExn -> raise (TypingError (BracketExprBoundVar (te,ctx())))
+      with Subst.UnshiftExn -> raise (Typing_error (BracketExprBoundVar (te,ctx())))
     in
     let exp_ty2 =
       try unshift_n sg (LList.len sigma) exp_ty
       with Subst.UnshiftExn ->
-        raise (TypingError (BracketExpectedTypeBoundVar (te,ctx(),exp_ty)))
+        raise (Typing_error (BracketExpectedTypeBoundVar (te,ctx(),exp_ty)))
     in
     let _ =
       try unshift_n sg delta.padding exp_ty2
       with Subst.UnshiftExn ->
-        raise (TypingError (BracketExpectedTypeRightVar (te,ctx(),exp_ty)))
+        raise (Typing_error (BracketExpectedTypeRightVar (te,ctx(),exp_ty)))
     in
     ( {delta with bracket = true}, lst)
   | Var (l,x,n,[]) when n >= LList.len sigma ->
@@ -348,7 +348,7 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
       let k = LList.len sigma in
       (* Bracket may introduce circularity (variable's expected type depending on itself *)
       if delta.bracket && Subst.occurs (n-k) exp_ty
-      then raise (TypingError (TypingCircularity(l,x,n,ctx(),exp_ty)));
+      then raise (Typing_error (TypingCircularity(l,x,n,ctx(),exp_ty)));
       if pc_in delta (n-k)
       then
         let inf_ty = Subst.shift k (pc_get delta (n-k)) in
@@ -356,21 +356,21 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
       else
         ( try ( pc_add delta (n-k) l x (unshift_n sg k exp_ty), lst )
           with Subst.UnshiftExn ->
-            raise (TypingError (FreeVariableDependsOnBoundVariable (l,x,n,ctx(),exp_ty))) )
+            raise (Typing_error (FreeVariableDependsOnBoundVariable (l,x,n,ctx(),exp_ty))) )
     end
   | Var (l,x,n,args) when n >= LList.len sigma ->
     begin
       let k = LList.len sigma in
       (* Bracket may introduce circularity (variable's expected type depending on itself *)
       if delta.bracket && Subst.occurs (n-k) exp_ty
-      then raise (TypingError (TypingCircularity(l,x,n,ctx(),exp_ty)));
+      then raise (Typing_error (TypingCircularity(l,x,n,ctx(),exp_ty)));
       let (args2, last) = get_last args in
       match last with
       | Var (l2,x2,n2,[]) ->
         check_pattern sg delta sigma
           (mk_Pi l2 x2 (get_type (LList.lst sigma) l2 x2 n2) (Subst.subst_n n2 x2 exp_ty) )
           lst (Var(l,x,n,args2))
-      | _ -> raise (TypingError (CannotInferTypeOfPattern (pat,ctx ()))) (* not a pattern *)
+      | _ -> raise (Typing_error (CannotInferTypeOfPattern (pat,ctx ()))) (* not a pattern *)
     end
   | _ ->
     begin
@@ -392,7 +392,7 @@ let subst_context (sub:SS.t) (ctx:typed_context) : typed_context =
 
 let check_rule sg (rule:untyped_rule) : SS.t * typed_rule =
   let fail = if !fail_on_unsatisfiable_constraints
-    then (fun x -> raise (TypingError (UnsatisfiableConstraints (rule,x))))
+    then (fun x -> raise (Typing_error (UnsatisfiableConstraints (rule,x))))
     else (fun (q,t1,t2) ->
         Debug.(debug D_warn "At %a: unsatisfiable constraint: %a ~ %a%s"
                  pp_loc (get_loc_rule rule)
@@ -414,7 +414,7 @@ let check_rule sg (rule:untyped_rule) : SS.t * typed_rule =
             pp_untyped_rule rule;
           let ctx_name n = let _,name,_ = List.nth ctx n in name in
           debug D_rule "Tried inferred typing substitution: %a" (SS.pp ctx_name) sub);
-        raise (TypingError (NotImplementedFeature (get_loc_pat rule.pat) ) )
+        raise (Typing_error (NotImplementedFeature (get_loc_pat rule.pat) ) )
   in
   check sg ctx2 ri2 ty_le2;
   Debug.(debug D_rule "[ %a ] %a --> %a"

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -30,7 +30,7 @@ type typing_error =
   | Convertible                        of loc * term * term
   | Inhabit                            of loc * term * term
 
-exception TypingError of typing_error
+exception Typing_error of typing_error
 
 type typ = term
 

--- a/parsing/dune
+++ b/parsing/dune
@@ -5,6 +5,6 @@
     (flags (--external-tokens Tokens)))
 
 (library
-    (name parsing)
-    (public_name dedukti.parsing)
+    (name parsers)
+    (public_name dedukti.parsers)
     (libraries kernel))


### PR DESCRIPTION
As requested by Gaspard, this is the changes of another-api to the kernel more or less based from dune. I did some hackish stuff in the API that are fixed in PR #190.

TODO:
- [ ] get_file should take an input channel
- [ ] there should be a way to close a file