### PR TITLE
Fixed exception naming

### DIFF
--- a/api/env.ml
+++ b/api/env.ml
@@ -32,12 +32,12 @@ type env_error =
   | BracketScopingError
   | AssertError
 
-exception EnvError of mident option * loc * env_error
+exception Env_error of mident option * loc * env_error
 
 let raise_as_env md lc = function
-  | SignatureError e -> raise (EnvError (Some md, lc, (EnvErrorSignature e)))
-  | TypingError    e -> raise (EnvError (Some md, lc, (EnvErrorType      e)))
-  | RuleError      e -> raise (EnvError (Some md, lc, (EnvErrorRule      e)))
+  | Signature_error e -> raise (Env_error (Some md, lc, (EnvErrorSignature e)))
+  | Typing_error    e -> raise (Env_error (Some md, lc, (EnvErrorType      e)))
+  | Rule_error      e -> raise (Env_error (Some md, lc, (EnvErrorRule      e)))
   | ex               -> raise ex
 
 let check_arity = ref true
@@ -88,7 +88,7 @@ struct
   let get_signature () = !sg
 
   let raise_as_env x = raise_as_env (get_name()) x
-  let raise_env lc err = raise (EnvError (Some (get_name()), lc, err))
+  let raise_env lc err = raise (Env_error (Some (get_name()), lc, err))
 
   module Printer = Pp.Make(struct let get_name = get_name end)
 
@@ -123,7 +123,7 @@ struct
   let _declare lc (id:ident) st ty : unit =
     match T.inference !sg ty with
     | Kind | Type _ -> Signature.add_declaration !sg lc id st ty
-    | s -> raise (Typing.TypingError (Typing.SortExpected (ty,[],s)))
+    | s -> raise (Typing.Typing_error (Typing.SortExpected (ty,[],s)))
 
   let is_static lc cst = Signature.is_static !sg lc cst
 
@@ -152,7 +152,7 @@ struct
   (** Checks that all rule are left-linear. *)
   let _check_ll (r:rule_infos) : unit =
     List.iter
-      (function Linearity _ -> raise (EnvError (Some (get_name()), r.l, NonLinearRule r.name)) | _ -> ())
+      (function Linearity _ -> raise (Env_error (Some (get_name()), r.l, NonLinearRule r.name)) | _ -> ())
       r.constraints
 
   let _add_rules rs =

--- a/api/env.mli
+++ b/api/env.mli
@@ -18,7 +18,7 @@ type env_error =
   | BracketScopingError
   | AssertError
 
-exception EnvError of mident option * loc * env_error
+exception Env_error of mident option * loc * env_error
 
 (** {2 Debugging} *)
 

--- a/api/errors.ml
+++ b/api/errors.ml
@@ -250,7 +250,7 @@ let fail_dep_error fail md errid err =
 
 let code : exn -> int =
   function
-  | Env.EnvError (_,_,err) ->
+  | Env.Env_error (_,_,err) ->
     begin
       match err with
       | EnvErrorType e ->
@@ -331,7 +331,7 @@ let graceful_fail file exn =
   let errid = if code = -1 then "UNCAUGHT EXCEPTION" else string_of_int code in
   let fail md lc = fail_exit 3 errid file md (Some lc) in
   match exn with
-  | Env.EnvError (md,lc,err) ->
+  | Env.Env_error (md,lc,err) ->
     begin
       match err with
       | Env.EnvErrorSignature e -> fail_signature_error file md errid lc e
@@ -361,7 +361,7 @@ let graceful_fail file exn =
     fail None lc "Scoping error: %s@." msg
   | Dep.Dep_error dep ->
     fail_dep_error file None errid dep
-  | Basic.NotDirectory ndir ->
+  | Basic.Not_directory ndir ->
     fail_exit 1 "OPTIONS" None None None "Invalid option for -I: %s is not a directory@." ndir
   | Sys_error err ->
     fail_exit 1 "SYSTEM" None None None "%s@." err

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -37,14 +37,14 @@ let handle_entry md e =
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (Some md,l,Env.AssertError)) )
+      | false, true  -> raise (Env.Env_error (Some md,l,Env.AssertError)) )
   | Check(l, assrt, neg, HasType(te,ty)) ->
     let succ = try E.check te ty; not neg with _ -> neg in
     ( match succ, assrt with
       | true , false -> Format.printf "YES@."
       | true , true  -> ()
       | false, false -> Format.printf "NO@."
-      | false, true  -> raise (Env.EnvError (Some md,l,Env.AssertError)) )
+      | false, true  -> raise (Env.Env_error (Some md,l,Env.AssertError)) )
   | DTree(lc,m,v) ->
     let m = match m with None -> E.get_name () | Some m -> m in
     let cst = mk_name m v in

--- a/kernel/basic.ml
+++ b/kernel/basic.ml
@@ -67,12 +67,12 @@ let dloc = (-1,-1)
 let mk_loc l c = (l,c)
 let of_loc l = l
 
-exception NotDirectory of string
+exception Not_directory of string
 let path = ref []
 let get_path () = !path
 let add_path s =
   if not (Sys.is_directory s)
-  then raise (NotDirectory s)
+  then raise (Not_directory s)
   else path := s :: !path
 
 (** {2 Debugging} *)
@@ -86,11 +86,11 @@ module Debug = struct
 
   let set = Hashtbl.replace flag_message
 
-  exception DebugMessageNotSet of flag
+  exception Debug_message_not_set of flag
 
   let get (fl:flag ) : (string*bool) =
     try Hashtbl.find flag_message fl
-    with Not_found -> raise (DebugMessageNotSet fl)
+    with Not_found -> raise (Debug_message_not_set fl)
 
   let message   (fl : flag ) : string = fst (get fl)
   let is_active (fl : flag ) : bool   = snd (get fl)

--- a/kernel/basic.mli
+++ b/kernel/basic.mli
@@ -78,7 +78,7 @@ val mk_loc : int -> int -> loc
 val of_loc : loc -> int * int
 (** [of_loc l] returns the line and the column associated to the position*)
 
-exception NotDirectory of string
+exception Not_directory of string
 
 val add_path : string -> unit
 (** Raises NotDirectory when given string is not a path to a directory *)

--- a/kernel/confluence.ml
+++ b/kernel/confluence.ml
@@ -14,7 +14,7 @@ type confluence_error =
   | MaybeConfluent of string
   | CCFailure      of string
 
-exception ConfluenceError of confluence_error
+exception Confluence_error of confluence_error
 
 module IdMap = Map.Make(
   struct
@@ -199,7 +199,7 @@ let check () =
         let answer = input_line input in
         let _ = Unix.close_process_in input in
         answer
-      with End_of_file -> raise (ConfluenceError (CCFailure cmd))
+      with End_of_file -> raise (Confluence_error (CCFailure cmd))
     in
     if String.compare answer "YES" != 0
     then (
@@ -208,7 +208,7 @@ let check () =
         | "NO"    -> NotConfluent   cmd
         | "MAYBE" -> MaybeConfluent cmd
         | _       -> CCFailure      cmd in
-      raise (ConfluenceError error)
+      raise (Confluence_error error)
     )
 
 let add_constant cst = try_out (fun (_,out) ->

--- a/kernel/confluence.mli
+++ b/kernel/confluence.mli
@@ -10,7 +10,7 @@ type confluence_error =
   | MaybeConfluent of string
   | CCFailure      of string
 
-exception ConfluenceError of confluence_error
+exception Confluence_error of confluence_error
 
 val set_cmd : string -> unit
 val initialize : unit -> unit

--- a/kernel/dtree.ml
+++ b/kernel/dtree.ml
@@ -10,7 +10,7 @@ type dtree_error =
   | HeadSymbolMismatch  of loc * name * name
   | ArityInnerMismatch  of loc * ident * ident
 
-exception DtreeError of dtree_error
+exception Dtree_error of dtree_error
 
 type case =
   | CConst of int * name
@@ -136,7 +136,7 @@ let specialize_rule (c:int) (nargs:int) (r:rule_infos) : rule_infos =
     else (* size <= i < size+nargs *)
       let check_args id pats =
         if ( Array.length pats != nargs ) then
-          raise (DtreeError(ArityInnerMismatch(r.l, Basic.id r.cst, id)));
+          raise (Dtree_error(ArityInnerMismatch(r.l, Basic.id r.cst, id)));
         pats.( i - size)
       in
       match r.pats.(c) with
@@ -268,7 +268,7 @@ let of_rules = function
     List.iter
       (fun x ->
          if not (name_eq x.cst name)
-         then raise (DtreeError (HeadSymbolMismatch (x.l,x.cst,name)));
+         then raise (Dtree_error (HeadSymbolMismatch (x.l,x.cst,name)));
          let arity = List.length x.args in
          arities := add !arities arity)
       rs;

--- a/kernel/dtree.mli
+++ b/kernel/dtree.mli
@@ -9,7 +9,7 @@ type dtree_error =
   | HeadSymbolMismatch  of loc * name * name
   | ArityInnerMismatch  of loc * ident * ident
 
-exception DtreeError of dtree_error
+exception Dtree_error of dtree_error
 
 (** {2 Decision Trees} *)
 
@@ -72,5 +72,5 @@ val of_rules : rule_infos list -> t
     Returns a list of arities and corresponding decision trees.
     Invariant : arities must be sorted in decreasing order.
     (see use case in [state_whnf] in [reduction.ml])
-    May raise DtreeError.
+    May raise Dtree_error.
 *)

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -143,7 +143,7 @@ and test (rn:Rule.rule_name) (sg:Signature.t)
      let t2 = term_of_state { ctx; term=t; stack=[] } in
      if C.matching_test (Bracket (i,t)) rn sg t1 t2
      then test rn sg ctx tl
-     else raise (Signature.SignatureError(Signature.GuardNotSatisfied(get_loc t1, t1, t2)))
+     else raise (Signature.Signature_error(Signature.GuardNotSatisfied(get_loc t1, t1, t2)))
 
 and find_case (st:state) (cases:(case*dtree) list)
     (default:dtree option) : (dtree * stack) option =

--- a/kernel/rule.ml
+++ b/kernel/rule.ml
@@ -81,7 +81,7 @@ type rule_error =
   | NonLinearNonEqArguments        of loc * ident
   (* FIXME: the reason for this exception should be formalized on paper ! *)
 
-exception RuleError of rule_error
+exception Rule_error of rule_error
 
 let rec pp_pattern out pattern =
   match pattern with
@@ -210,7 +210,7 @@ let check_patterns (esize:int) (pats:pattern list) : wf_pattern list * pattern_i
     !context_size - 1 in
   let extract_db k = function
     | Var (_,_,n,[]) when n<k -> n
-    | p -> raise (RuleError (BoundVariableExpected p))
+    | p -> raise (Rule_error (BoundVariableExpected p))
   in
   let rec aux (k:int) (pat:pattern) : wf_pattern =
     match pat with
@@ -222,11 +222,11 @@ let check_patterns (esize:int) (pats:pattern list) : wf_pattern list * pattern_i
       let args' = List.map (extract_db k) args in
       (* Miller variables should be applied to distinct variables *)
       if not (all_distinct args')
-      then raise (RuleError (DistinctBoundVariablesExpected (l,x)));
+      then raise (Rule_error (DistinctBoundVariablesExpected (l,x)));
       let nb_args' = List.length args' in
       if IntHashtbl.mem arity (n-k)
       then if nb_args' <> IntHashtbl.find arity (n-k)
-        then raise (RuleError (NonLinearNonEqArguments(l,x)))
+        then raise (Rule_error (NonLinearNonEqArguments(l,x)))
         else
           let nvar = fresh_var nb_args' in
           constraints := Linearity(nvar, n-k) :: !constraints;
@@ -237,7 +237,7 @@ let check_patterns (esize:int) (pats:pattern list) : wf_pattern list * pattern_i
     | Brackets t ->
       let unshifted =
         try Subst.unshift k t
-        with Subst.UnshiftExn -> raise (RuleError (VariableBoundOutsideTheGuard t))
+        with Subst.UnshiftExn -> raise (Rule_error (VariableBoundOutsideTheGuard t))
         (* Note: A different exception is previously raised at rule type-checking for this. *)
       in
       let nvar = fresh_var 0 in
@@ -256,7 +256,7 @@ let to_rule_infos (r:'a rule) : rule_infos =
   let ctx_size = List.length r.ctx in
   let (l,cst,args) = match r.pat with
     | Pattern (l,cst,args) -> (l, cst, args)
-    | Var (l,x,_,_) ->  raise (RuleError (AVariableIsNotAPattern (l,x)))
+    | Var (l,x,_,_) ->  raise (Rule_error (AVariableIsNotAPattern (l,x)))
     | Lambda _ | Brackets _ -> assert false (* already raised at the parsing level *)
   in
   let (pats2,infos) = check_patterns ctx_size args in

--- a/kernel/rule.mli
+++ b/kernel/rule.mli
@@ -79,7 +79,7 @@ type rule_error =
   | AVariableIsNotAPattern         of loc * ident
   | NonLinearNonEqArguments        of loc * ident
 
-exception RuleError of rule_error
+exception Rule_error of rule_error
 
 (** {2 Rule infos} *)
 

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -23,7 +23,7 @@ type signature_error =
   | GuardNotSatisfied     of loc * term * term
   | CouldNotExportModule  of mident * string
 
-exception SignatureError of signature_error
+exception Signature_error of signature_error
 
 module HMd = Hashtbl.Make(
   struct
@@ -109,15 +109,15 @@ let unmarshal (lc:loc) (m:string) : string list * rw_infos HId.t * rule_infos li
     let chan = find_dko m in
     let ver:string = Marshal.from_channel chan in
     if String.compare ver Version.version <> 0
-    then raise (SignatureError (UnmarshalBadVersionNumber (lc,m)));
+    then raise (Signature_error (UnmarshalBadVersionNumber (lc,m)));
     let deps:string list         = Marshal.from_channel chan in
     let ctx:rw_infos HId.t       = Marshal.from_channel chan in
     let ext:rule_infos list list = Marshal.from_channel chan in
     close_in chan; (deps,ctx,ext)
   with
-  | Sys_error s -> raise (SignatureError (UnmarshalSysError (lc,m,s)))
-  | SignatureError s -> raise (SignatureError s)
-  | _ -> raise (SignatureError (UnmarshalUnknown (lc,m)))
+  | Sys_error s -> raise (Signature_error (UnmarshalSysError (lc,m,s)))
+  | Signature_error s -> raise (Signature_error s)
+  | _ -> raise (Signature_error (UnmarshalUnknown (lc,m)))
 
 
 let fold_symbols f sg =
@@ -140,13 +140,13 @@ let check_confluence_on_import lc (md:mident) (ctx:rw_infos HId.t) : unit =
   Debug.debug Confluence.D_confluence
     "Checking confluence after loading module '%a'..." pp_mident md;
   try Confluence.check () with
-  | Confluence.ConfluenceError e -> raise (SignatureError (ConfluenceErrorImport (lc,md,e)))
+  | Confluence.Confluence_error e -> raise (Signature_error (ConfluenceErrorImport (lc,md,e)))
 
 let add_external_declaration sg lc cst st ty =
   try
     let env = HMd.find sg.tables (md cst) in
     if HId.mem env (id cst)
-    then raise (SignatureError (AlreadyDefinedSymbol (lc, cst)))
+    then raise (Signature_error (AlreadyDefinedSymbol (lc, cst)))
     else HId.replace env (id cst) {stat=st; ty=ty; rules=[]; decision_tree=None}
   with Not_found ->
     HMd.replace sg.tables (md cst) (HId.create 11);
@@ -175,13 +175,13 @@ and add_rule_infos sg (lst:rule_infos list) : unit =
     let infos, env =
       try get_info_env sg r.l r.cst
       with
-      | SignatureError (SymbolNotFound _)
-      | SignatureError (UnmarshalUnknown _) when not !fail_on_symbol_not_found ->
+      | Signature_error (SymbolNotFound _)
+      | Signature_error (UnmarshalUnknown _) when not !fail_on_symbol_not_found ->
         add_external_declaration sg r.l r.cst Definable (mk_Kind);
         get_info_env sg r.l r.cst
     in
     if infos.stat = Static && !fail_on_symbol_not_found
-    then raise (SignatureError (CannotAddRewriteRules (r.l,r.cst)));
+    then raise (Signature_error (CannotAddRewriteRules (r.l,r.cst)));
     HId.replace env (id r.cst) {infos with rules = infos.rules @ rs; decision_tree= None}
 
 and compute_dtree sg (lc:Basic.loc) (cst:Basic.name) : Dtree.t option =
@@ -191,7 +191,7 @@ and compute_dtree sg (lc:Basic.loc) (cst:Basic.name) : Dtree.t option =
   | None, (_::_ as rules) ->
     let trees =
       try Dtree.of_rules rules
-      with Dtree.DtreeError e -> raise (SignatureError (CannotBuildDtree e))
+      with Dtree.Dtree_error e -> raise (Signature_error (CannotBuildDtree e))
     in
     HId.replace env (id cst) {infos with decision_tree=Some trees};
     Some trees
@@ -204,7 +204,7 @@ and get_info_env sg lc cst =
     with Not_found -> import sg lc md; HMd.find sg.tables md
   in
   try (HId.find env (id cst), env)
-  with Not_found -> raise (SignatureError (SymbolNotFound (lc,cst)))
+  with Not_found -> raise (Signature_error (SymbolNotFound (lc,cst)))
 
 and get_infos sg lc cst = fst (get_info_env sg lc cst)
 
@@ -231,7 +231,7 @@ let import_signature sg sg_ext =
 let export sg =
   let mod_table = HMd.find sg.tables sg.name in
   if not (marshal sg.file (get_deps sg) mod_table sg.external_rules)
-  then raise (SignatureError (CouldNotExportModule (sg.name, sg.file)))
+  then raise (Signature_error (CouldNotExportModule (sg.name, sg.file)))
 
 (******************************************************************************)
 
@@ -270,5 +270,5 @@ let add_rules sg = function
                "Checking confluence after adding rewrite rules on symbol '%a'"
                pp_name r.cst);
       try Confluence.check ()
-      with Confluence.ConfluenceError e -> raise (SignatureError (ConfluenceErrorRules (r.l,rs,e)))
-    with RuleError e -> raise (SignatureError (CannotMakeRuleInfos e))
+      with Confluence.Confluence_error e -> raise (Signature_error (ConfluenceErrorRules (r.l,rs,e)))
+    with Rule_error e -> raise (Signature_error (CannotMakeRuleInfos e))

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -20,7 +20,7 @@ type signature_error =
   | GuardNotSatisfied     of loc * term * term
   | CouldNotExportModule  of mident * string
 
-exception SignatureError of signature_error
+exception Signature_error of signature_error
 
 type staticity = Static | Definable
 

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -38,7 +38,7 @@ type typing_error =
   | Convertible                        of loc * term * term
   | Inhabit                            of loc * term * term
 
-exception TypingError of typing_error
+exception Typing_error of typing_error
 
 module type S = sig
   val infer       : Signature.t -> typed_context -> term -> typ
@@ -58,21 +58,21 @@ struct
 
   let get_type ctx l x n =
     try let (_,_,ty) = List.nth ctx n in Subst.shift (n+1) ty
-    with Failure _ -> raise (TypingError (VariableNotFound (l,x,n,ctx)))
+    with Failure _ -> raise (Typing_error (VariableNotFound (l,x,n,ctx)))
 
   let extend_ctx a ctx = function
     | Type _ -> a::ctx
     | Kind when !coc -> a::ctx
     | ty_a ->
       let (_,_,te) = a in
-      raise (TypingError (ConvertibilityError (te, ctx, mk_Type dloc, ty_a)))
+      raise (Typing_error (ConvertibilityError (te, ctx, mk_Type dloc, ty_a)))
 
   (* ********************** TYPE CHECKING/INFERENCE FOR TERMS  *)
 
   let rec infer sg (ctx:typed_context) (te:term) : typ =
     Debug.(debug D_typeChecking "Inferring: %a" pp_term te);
     match te with
-    | Kind -> raise (TypingError KindIsNotTypable)
+    | Kind -> raise (Typing_error KindIsNotTypable)
     | Type _ -> mk_Kind
     | DB (l,x,n) -> get_type ctx l x n
     | Const (l,cst) -> Signature.get_type sg l cst
@@ -84,15 +84,15 @@ struct
       let ty_b = infer sg ctx2 b in
       ( match ty_b with
         | Kind | Type _ -> ty_b
-        | _ -> raise (TypingError (SortExpected (b, ctx2, ty_b))) )
+        | _ -> raise (Typing_error (SortExpected (b, ctx2, ty_b))) )
     | Lam  (l,x,Some a,b) ->
       let ty_a = infer sg ctx a in
       let ctx2 = extend_ctx (l,x,a) ctx ty_a in
       let ty_b = infer sg ctx2 b in
       ( match ty_b with
-        | Kind -> raise (TypingError (InexpectedKind (b, ctx2)))
+        | Kind -> raise (Typing_error (InexpectedKind (b, ctx2)))
         | _ -> mk_Pi l x a ty_b )
-    | Lam  (l,_,None,_) -> raise (TypingError (DomainFreeLambda l))
+    | Lam  (l,_,None,_) -> raise (Typing_error (DomainFreeLambda l))
 
   and check sg (ctx:typed_context) (te:term) (ty_exp:typ) : unit =
     Debug.(debug D_typeChecking "Checking (%a): %a : %a"
@@ -106,11 +106,11 @@ struct
             | Some a' ->
                ignore(infer sg ctx a');
                if not (R.are_convertible sg a a')
-               then raise (TypingError (ConvertibilityError ((mk_DB l x 0),ctx,a,a')))
+               then raise (Typing_error (ConvertibilityError ((mk_DB l x 0),ctx,a,a')))
             | _ -> ()
           );
           check sg ((l,x,a)::ctx) b ty_b
-        | _ -> raise (TypingError (ProductExpected (te,ctx,ty_exp)))
+        | _ -> raise (Typing_error (ProductExpected (te,ctx,ty_exp)))
       end
     | _ ->
       let ty_inf = infer sg ctx te in
@@ -118,13 +118,13 @@ struct
                pp_term ty_inf pp_term ty_exp);
       if not (R.are_convertible sg ty_inf ty_exp) then
         let ty_exp' = rename_vars_with_typed_context ctx ty_exp in
-        raise (TypingError (ConvertibilityError (te,ctx,ty_exp',ty_inf)))
+        raise (Typing_error (ConvertibilityError (te,ctx,ty_exp',ty_inf)))
 
   and check_app sg (ctx:typed_context) (f,ty_f:term*typ) (arg:term) : term*typ =
     match R.whnf sg ty_f with
     | Pi (_,_,a,b) ->
       let _ = check sg ctx arg a in (mk_App f arg [], Subst.subst b arg )
-    | _ -> raise (TypingError ( ProductExpected (f,ctx,ty_f)))
+    | _ -> raise (Typing_error ( ProductExpected (f,ctx,ty_f)))
 
   let inference sg (te:term) : typ = infer sg [] te
 
@@ -389,7 +389,7 @@ let rec infer_pattern sg (delta:partial_context) (sigma:context2)
     in (ty,delta2,lst2)
   | Var _ | Brackets _ | Lambda _ ->
     let ctx = (LList.lst sigma)@(pc_to_context_wp delta) in
-    raise (TypingError (CannotInferTypeOfPattern (pat,ctx)))
+    raise (Typing_error (CannotInferTypeOfPattern (pat,ctx)))
 
 and infer_pattern_aux sg
     (sigma,f,ty_f,delta,lst : context2*term*typ*partial_context*constraints)
@@ -401,7 +401,7 @@ and infer_pattern_aux sg
     ( sigma, Term.mk_App f arg' [], Subst.subst b arg', delta2 , lst2 )
   | ty_f ->
     let ctx = (LList.lst sigma)@(pc_to_context_wp delta) in
-    raise (TypingError (ProductExpected (f,ctx,ty_f)))
+    raise (Typing_error (ProductExpected (f,ctx,ty_f)))
 
 and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
     (lst:constraints) (pat:pattern) : partial_context * constraints =
@@ -412,22 +412,22 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
     begin
       match R.whnf sg exp_ty with
       | Pi (_,_,a,b) -> check_pattern sg delta (LList.cons (l,x,a) sigma) b lst p
-      | _            -> raise (TypingError ( ProductExpected (pattern_to_term pat,ctx (),exp_ty)))
+      | _            -> raise (Typing_error ( ProductExpected (pattern_to_term pat,ctx (),exp_ty)))
     end
   | Brackets te ->
     let _ =
       try Subst.unshift (LList.len sigma) te
-      with Subst.UnshiftExn -> raise (TypingError (BracketExprBoundVar (te,ctx())))
+      with Subst.UnshiftExn -> raise (Typing_error (BracketExprBoundVar (te,ctx())))
     in
     let exp_ty2 =
       try unshift_n sg (LList.len sigma) exp_ty
       with Subst.UnshiftExn ->
-        raise (TypingError (BracketExpectedTypeBoundVar (te,ctx(),exp_ty)))
+        raise (Typing_error (BracketExpectedTypeBoundVar (te,ctx(),exp_ty)))
     in
     let _ =
       try unshift_n sg delta.padding exp_ty2
       with Subst.UnshiftExn ->
-        raise (TypingError (BracketExpectedTypeRightVar (te,ctx(),exp_ty)))
+        raise (Typing_error (BracketExpectedTypeRightVar (te,ctx(),exp_ty)))
     in
     ( {delta with bracket = true}, lst)
   | Var (l,x,n,[]) when n >= LList.len sigma ->
@@ -435,7 +435,7 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
       let k = LList.len sigma in
       (* Bracket may introduce circularity (variable's expected type depending on itself *)
       if delta.bracket && Subst.occurs (n-k) exp_ty
-      then raise (TypingError (TypingCircularity(l,x,n,ctx(),exp_ty)));
+      then raise (Typing_error (TypingCircularity(l,x,n,ctx(),exp_ty)));
       if pc_in delta (n-k)
       then
         let inf_ty = Subst.shift k (pc_get delta (n-k)) in
@@ -443,21 +443,21 @@ and check_pattern sg (delta:partial_context) (sigma:context2) (exp_ty:typ)
       else
         ( try ( pc_add delta (n-k) l x (unshift_n sg k exp_ty), lst )
           with Subst.UnshiftExn ->
-            raise (TypingError (FreeVariableDependsOnBoundVariable (l,x,n,ctx(),exp_ty))) )
+            raise (Typing_error (FreeVariableDependsOnBoundVariable (l,x,n,ctx(),exp_ty))) )
     end
   | Var (l,x,n,args) when n >= LList.len sigma ->
     begin
       let k = LList.len sigma in
       (* Bracket may introduce circularity (variable's expected type depending on itself *)
       if delta.bracket && Subst.occurs (n-k) exp_ty
-      then raise (TypingError (TypingCircularity(l,x,n,ctx(),exp_ty)));
+      then raise (Typing_error (TypingCircularity(l,x,n,ctx(),exp_ty)));
       let (args2, last) = get_last args in
       match last with
       | Var (l2,x2,n2,[]) ->
         check_pattern sg delta sigma
           (mk_Pi l2 x2 (get_type (LList.lst sigma) l2 x2 n2) (Subst.subst_n n2 x2 exp_ty) )
           lst (Var(l,x,n,args2))
-      | _ -> raise (TypingError (CannotInferTypeOfPattern (pat,ctx ()))) (* not a pattern *)
+      | _ -> raise (Typing_error (CannotInferTypeOfPattern (pat,ctx ()))) (* not a pattern *)
     end
   | _ ->
     begin
@@ -495,7 +495,7 @@ let check_type_annotations sg sub typed_ctx annot_ctx =
             let ty2  = SS.apply sub 0 (Subst.shift depth ty ) in
             let ty2' = SS.apply sub 0 (Subst.shift depth ty') in
             if not (R.are_convertible sg ty2 ty2')
-            then raise (TypingError (AnnotConvertibilityError (l,x,ctx,ty',ty)))
+            then raise (Typing_error (AnnotConvertibilityError (l,x,ctx,ty',ty)))
       end;
       aux ((l,x,ty)::ctx) (depth+1) ctx1' ctx2'
     | [], [] -> ()
@@ -505,7 +505,7 @@ let check_type_annotations sg sub typed_ctx annot_ctx =
 let check_rule sg (rule:partially_typed_rule) : SS.t * typed_rule =
   Debug.(debug D_rule "Inferring variables type and constraints from LHS");
   let fail = if !fail_on_unsatisfiable_constraints
-    then (fun x -> raise (TypingError (UnsatisfiableConstraints (rule,x))))
+    then (fun x -> raise (Typing_error (UnsatisfiableConstraints (rule,x))))
     else (fun (q,t1,t2) ->
         Debug.(debug D_warn "At %a: unsatisfiable constraint: %a ~ %a%s"
                  pp_loc (get_loc_rule rule)
@@ -526,7 +526,7 @@ let check_rule sg (rule:partially_typed_rule) : SS.t * typed_rule =
           pp_part_typed_rule rule;
         let ctx_name n = let _,name,_ = List.nth ctx n in name in
         debug D_rule "Tried inferred typing substitution: %a" (SS.pp ctx_name) sub);
-      raise (TypingError (NotImplementedFeature (get_loc_pat rule.pat) ) )
+      raise (Typing_error (NotImplementedFeature (get_loc_pat rule.pat) ) )
   in
   Debug.(debug D_rule "Typechecking rule");
   check sg ctx2 ri2 ty_le2;

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -31,7 +31,7 @@ type typing_error =
   | Convertible                        of loc * term * term
   | Inhabit                            of loc * term * term
 
-exception TypingError of typing_error
+exception Typing_error of typing_error
 
 type typ = term
 


### PR DESCRIPTION
This is in accordance with the [OCaml Programming Guidelines](https://ocaml.org/learn/tutorials/guidelines.html#Separate-words-by-underscores-int-of-string-not-intOfString)

It should help reduce the diff of #190 .