### PR TITLE
Implementation of debug flags as references

### DIFF
--- a/api/env.ml
+++ b/api/env.ml
@@ -9,14 +9,14 @@ exception DebugFlagNotRecognized of char
 
 let set_debug_mode =
   String.iter (function
-      | 'q' -> Debug.disable_flag Debug.D_warn
-      | 'n' -> Debug.enable_flag  Debug.D_notice
-      | 'o' -> Debug.enable_flag  Signature.D_module
-      | 'c' -> Debug.enable_flag  Confluence.D_confluence
-      | 'u' -> Debug.enable_flag  Typing.D_rule
-      | 't' -> Debug.enable_flag  Typing.D_typeChecking
-      | 'r' -> Debug.enable_flag  Reduction.D_reduce
-      | 'm' -> Debug.enable_flag  Dtree.D_matching
+      | 'q' -> Debug.disable_flag Debug.d_warn
+      | 'n' -> Debug.enable_flag  Debug.d_notice
+      | 'o' -> Debug.enable_flag  Signature.d_module
+      | 'c' -> Debug.enable_flag  Confluence.d_confluence
+      | 'u' -> Debug.enable_flag  Typing.d_rule
+      | 't' -> Debug.enable_flag  Typing.d_typeChecking
+      | 'r' -> Debug.enable_flag  Reduction.d_reduce
+      | 'm' -> Debug.enable_flag  Matching.d_matching
       | c -> raise (DebugFlagNotRecognized c)
     )
 

--- a/api/processor.ml
+++ b/api/processor.ml
@@ -15,27 +15,25 @@ module TypeChecker (E:Env.S) : S with type t = unit =
 struct
   module Printer = E.Printer
 
-  open Debug
-
   type t = unit
 
   let handle_entry e =
     let open Entry in
     match e with
     | Decl(lc,id,st,ty) ->
-      debug D_notice "Declaration of constant '%a'." pp_ident id;
+      Debug.(debug d_notice) "Declaration of constant '%a'." pp_ident id;
       E.declare lc id st ty
     | Def(lc,id,opaque,ty,te) ->
       let opaque_str = if opaque then " (opaque)" else "" in
-      debug D_notice "Definition of symbol '%a'%s." pp_ident id opaque_str;
+      Debug.(debug d_notice) "Definition of symbol '%a'%s." pp_ident id opaque_str;
       E.define lc id opaque te ty
     | Rules(_,rs) ->
       let open Rule in
       List.iter (fun (r:partially_typed_rule) ->
-          Debug.(debug D_notice "Adding rewrite rules: '%a'" Printer.print_rule_name r.name)) rs;
+          Debug.(debug d_notice "Adding rewrite rules: '%a'" Printer.print_rule_name r.name)) rs;
       let rs = E.add_rules rs in
       List.iter (fun (s,r) ->
-          Debug.debug Debug.D_notice "%a@.with the following constraints: %a"
+          Debug.debug Debug.d_notice "%a@.with the following constraints: %a"
             pp_typed_rule r (Subst.Subst.pp (fun n -> let _,n,_ = List.nth r.ctx n in n)) s) rs
     | Eval(_,red,te) ->
       let te = E.reduction ~red te in
@@ -66,7 +64,7 @@ struct
     | Print(_,s) -> Format.printf "%s@." s
     | Name(_,n) ->
       if not (mident_eq n (E.get_name()))
-      then Debug.(debug D_warn "Invalid #NAME directive ignored.@.")
+      then Debug.(debug d_warn "Invalid #NAME directive ignored.@.")
     | Require(lc,md) -> E.import lc md
 
   let get_data () = ()

--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -20,7 +20,7 @@ let run_on_file beautify export file =
   let input =
     try open_in file
     with e -> ErrorHandler.graceful_fail (Some file) e in
-  Debug.(debug Signature.D_module "Processing file '%s'..." file);
+  Debug.debug Signature.d_module "Processing file '%s'..." file;
   let md = E.init file in
   Confluence.initialize ();
   begin
@@ -38,7 +38,7 @@ let _ =
   let beautify     = ref false in
   let deprecated old_flag new_flag spec =
     let warning () =
-      Debug.(debug D_warn)
+      Debug.(debug d_warn)
         "[DEPRECATED] Flag %s is deprecated ! Use %s instead.@." old_flag new_flag in
     (old_flag,Arg.Tuple [Arg.Unit warning; spec], "")
   in

--- a/commands/dkprune.ml
+++ b/commands/dkprune.ml
@@ -23,15 +23,12 @@ end
 
 module Printer = Pp.Make(CustomSig)
 
-
-module D = Basic.Debug
-type D.flag += D_prune
-let _ = D.register_flag D_prune "Dkprune"
-let enable_log : unit -> unit = fun () -> D.enable_flag D_prune
+let d_prune = Debug.register_flag "Dkprune"
+let enable_log : unit -> unit = fun () -> Debug.enable_flag d_prune
 
 let gre fmt = "\027[32m" ^^ fmt ^^ "\027[0m%!"
 
-let log fmt = D.debug D_prune (gre fmt)
+let log fmt = Debug.debug d_prune (gre fmt)
 
 type constraints =
   {

--- a/kernel/basic.ml
+++ b/kernel/basic.ml
@@ -79,29 +79,13 @@ let add_path s =
 
 module Debug = struct
 
-  type flag  = ..
-  type flag += D_warn | D_notice
+  type flag = string * bool ref
+  let new_flag v m = m, ref v
+  let set value (_  ,fl) = fl := value
 
-  let flag_message : (flag, string * bool) Hashtbl.t = Hashtbl.create 8
-
-  let set = Hashtbl.replace flag_message
-
-  exception DebugMessageNotSet of flag
-
-  let get (fl:flag ) : (string*bool) =
-    try Hashtbl.find flag_message fl
-    with Not_found -> raise (DebugMessageNotSet fl)
-
-  let message   (fl : flag ) : string = fst (get fl)
-  let is_active (fl : flag ) : bool   = snd (get fl)
-
-  let register_flag fl m = set fl (m         , false)
-  let  enable_flag  fl   = set fl (message fl, true )
-  let disable_flag  fl   = set fl (message fl, false)
-
-  let _ =
-    set D_warn   ("Warning", true );
-    set D_notice ("Notice" , false)
+  let register_flag = new_flag false
+  let   enable_flag = set true
+  let  disable_flag = set false
 
   let do_debug fmt =
     Format.(kfprintf (fun _ -> pp_print_newline err_formatter (); pp_print_flush err_formatter ()) err_formatter fmt)
@@ -109,13 +93,16 @@ module Debug = struct
   let ignore_debug fmt =
     Format.(ifprintf err_formatter) fmt
 
-  let debug f =
-    if is_active f
-    then fun fmt -> do_debug ("[%s] " ^^ fmt) (message f)
+  let debug (msg,fl) =
+    if !fl
+    then fun fmt -> do_debug ("[%s] " ^^ fmt) msg
     else ignore_debug
   [@@inline]
 
-  let debug_eval f clos = if is_active f then clos ()
+  let debug_eval (_,fl) clos = if !fl then clos ()
+
+  let d_warn   = new_flag true  "Warning"
+  let d_notice = new_flag false "Notice"
 
 end
 

--- a/kernel/basic.mli
+++ b/kernel/basic.mli
@@ -89,13 +89,12 @@ val get_path : unit -> string list
 
 module Debug : sig
 
-  type flag  = ..
-  (** Extensible type  for debug flags *)
+  type flag
+  val d_warn   : flag
+  val d_notice : flag
 
-  type flag += D_warn | D_notice
-
-  (** [register_flag fl m] set the header of error messages tagged by [f] to be [m] *)
-  val register_flag : flag -> string -> unit
+  (** [register_flag msg] generates a new flag with error message [msg] *)
+  val register_flag : string -> flag
 
   (** Activates error messages associated to a flag *)
   val enable_flag : flag -> unit

--- a/kernel/confluence.ml
+++ b/kernel/confluence.ml
@@ -3,8 +3,7 @@ open Basic
 open Term
 open Rule
 
-type Debug.flag += D_confluence
-let _ = Debug.register_flag D_confluence "Confluence"
+let d_confluence = Debug.register_flag "Confluence"
 
 let pp_name fmt cst =
   fprintf fmt "%a_%a" pp_mident (md cst) pp_ident (id cst)
@@ -40,7 +39,7 @@ let initialize () =
     begin
       let (file,out) = Filename.open_temp_file "dkcheck" ".trs" in
       let fmt = formatter_of_out_channel out in
-      Debug.(debug D_confluence "Temporary file:%s" file);
+      Debug.(debug d_confluence "Temporary file:%s" file);
       file_out := (Some (file,out));
       fprintf fmt "\
 (FUN
@@ -192,7 +191,7 @@ let check () =
   | Some (file,out) ->
     flush out;
     let cmd = !confluence_command ^ " -p " ^ file in
-    Debug.(debug D_confluence "Checking confluence : %s" cmd);
+    Debug.(debug d_confluence "Checking confluence : %s" cmd);
     let input = Unix.open_process_in cmd in
     let answer =
       try

--- a/kernel/confluence.mli
+++ b/kernel/confluence.mli
@@ -3,7 +3,7 @@
 open Basic
 open Rule
 
-type Debug.flag += D_confluence
+val d_confluence : Debug.flag
 
 type confluence_error =
   | NotConfluent   of string

--- a/kernel/dtree.ml
+++ b/kernel/dtree.ml
@@ -3,9 +3,6 @@ open Term
 open Rule
 open Format
 
-type Debug.flag += D_matching
-let _ = Debug.register_flag D_matching "Matching"
-
 type dtree_error =
   | HeadSymbolMismatch  of loc * name * name
   | ArityInnerMismatch  of loc * ident * ident

--- a/kernel/dtree.mli
+++ b/kernel/dtree.mli
@@ -1,8 +1,6 @@
 open Basic
 open Rule
 
-type Debug.flag += D_matching
-
 (** {2 Error} *)
 
 type dtree_error =

--- a/kernel/matching.ml
+++ b/kernel/matching.ml
@@ -1,6 +1,8 @@
 open Basic
 open Term
 
+let d_matching = Debug.register_flag "Matching"
+
 exception NotUnifiable
 
 (** Solve the following problem for lambda term X:

--- a/kernel/matching.mli
+++ b/kernel/matching.mli
@@ -1,7 +1,8 @@
 (** Matching on terms *)
-
 open Basic
 open Term
+
+val d_matching : Debug.flag
 
 exception NotUnifiable
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -3,8 +3,7 @@ open Rule
 open Term
 open Dtree
 
-type Debug.flag += D_reduce
-let _ = Debug.register_flag D_reduce "Reduce"
+let d_reduce = Debug.register_flag "Reduce"
 
 type red_target   = Snf | Whnf
 type red_strategy = ByName | ByValue | ByStrongValue
@@ -277,7 +276,7 @@ let conversion_step : (term * term) -> (term * term) list -> (term * term) list 
     (b,b')::lst
   | Pi  (_,_,a,b), Pi  (_,_,a',b') -> (a,a') :: (b,b') :: lst
   | t1, t2 ->
-    Debug.(debug D_reduce "Not convertible: %a / %a" pp_term t1 pp_term t2 );
+    Debug.(debug d_reduce "Not convertible: %a / %a" pp_term t1 pp_term t2 );
     raise NotConvertible
 
 let rec are_convertible_lst sg : (term*term) list -> bool =

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -2,7 +2,7 @@
 open Basic
 open Term
 
-type Debug.flag += D_reduce
+val d_reduce : Debug.flag
 
 type red_target   = Snf | Whnf
 type red_strategy = ByName | ByValue | ByStrongValue

--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -4,8 +4,7 @@ open Basic
 open Term
 open Rule
 
-type Debug.flag += D_module
-let _ = Debug.register_flag D_module "Module"
+let d_module = Debug.register_flag "Module"
 
 let fail_on_symbol_not_found = ref true
 
@@ -137,7 +136,7 @@ let check_confluence_on_import lc (md:mident) (ctx:rw_infos HId.t) : unit =
     Confluence.add_rules infos.rules
   in
   HId.iter aux ctx;
-  Debug.debug Confluence.D_confluence
+  Debug.debug Confluence.d_confluence
     "Checking confluence after loading module '%a'..." pp_mident md;
   try Confluence.check () with
   | Confluence.ConfluenceError e -> raise (SignatureError (ConfluenceErrorImport (lc,md,e)))
@@ -156,7 +155,7 @@ let add_external_declaration sg lc cst st ty =
 (* Recursively load a module and its dependencies*)
 let rec import sg lc m =
   if HMd.mem sg.tables m
-  then Debug.(debug D_warn "Trying to import the already loaded module %s." (string_of_mident m))
+  then Debug.(debug d_warn "Trying to import the already loaded module %s." (string_of_mident m))
   else
     let (deps,ctx,ext) = unmarshal lc (string_of_mident m) in
     HMd.replace sg.tables m ctx;
@@ -164,7 +163,7 @@ let rec import sg lc m =
         let dep = mk_mident dep0 in
         if not (HMd.mem sg.tables dep) then import sg lc dep
       ) deps ;
-    Debug.(debug D_module "Loading module '%a'..." pp_mident m);
+    Debug.(debug d_module "Loading module '%a'..." pp_mident m);
     List.iter (fun rs -> add_rule_infos sg rs) ext;
     check_confluence_on_import lc m ctx
 
@@ -266,7 +265,7 @@ let add_rules sg = function
       if not (mident_eq sg.name (md r.cst)) then
         sg.external_rules <- rs::sg.external_rules;
       Confluence.add_rules rs;
-      Debug.(debug Confluence.D_confluence
+      Debug.(debug Confluence.d_confluence
                "Checking confluence after adding rewrite rules on symbol '%a'"
                pp_name r.cst);
       try Confluence.check ()

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -4,7 +4,7 @@ open Basic
 open Term
 open Rule
 
-type Debug.flag += D_module
+val d_module : Debug.flag
 
 type signature_error =
   | UnmarshalBadVersionNumber of loc * string

--- a/kernel/typing.mli
+++ b/kernel/typing.mli
@@ -4,7 +4,8 @@ open Basic
 
 (** Type checking/inference *)
 
-type Debug.flag += D_typeChecking | D_rule
+val d_typeChecking : Debug.flag
+val d_rule         : Debug.flag
 
 val coc : bool ref
 

--- a/parsing/scoping.ml
+++ b/parsing/scoping.ml
@@ -111,7 +111,7 @@ let scope_rule md (l,pname,pctx,md_opt,id,pargs,pri:prule) : partially_typed_rul
   if unused_vars
   then
     begin
-      Debug.(debug D_warn "Local variables in the rule:\n%a\nare not used (%a)")
+      Debug.(debug d_warn "Local variables in the rule:\n%a\nare not used (%a)")
         pp_prule (l,pname,pctx,md_opt,id,pargs,pri) pp_loc l;
       if has_brackets then
         raise @@ Scoping_error(l,"Unused variables in context may create scoping ambiguity in bracket")


### PR DESCRIPTION
New implementation of debug flag as references. This allows to retrieve a flag's current value by directly dereferencing it, sparing a systematic hash computation.

This should reduce diff of #203 