### PR TITLE
matching: Fix the API issue and call the correct function

### DIFF
--- a/kernel/matching.mli
+++ b/kernel/matching.mli
@@ -20,11 +20,12 @@ module type Reducer = sig
   val snf  : Signature.t -> term -> term
   val whnf : Signature.t -> term -> term
   val are_convertible : Signature.t -> term -> term -> bool
+  val constraint_convertibility : Rule.constr -> Rule.rule_name -> Signature.t -> term -> term -> bool
 end
 
 module type Matcher = sig
   val solve_problem :
-    Signature.t -> (int -> term Lazy.t) -> (int -> term Lazy.t list) ->
+    Rule.rule_name -> Signature.t -> (int -> term Lazy.t) -> (int -> term Lazy.t list) ->
     pre_matching_problem -> term Lazy.t LList.t option
   (** [solve_problem sg eq_conv ac_conv pb] solves the [pb] matching problem
       using the given functions to convert positions in the stack to actual

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -326,7 +326,7 @@ and gamma_rw (sg:Signature.t) (filter:(Rule.rule_name -> bool) option)
         in
         (* Convert problem on stack indices to a problem on terms *)
         begin
-          match M.solve_problem sg convert convert_ac matching_pb with
+          match M.solve_problem rule_name sg convert convert_ac matching_pb with
           | None -> bind_opt (rw stack) def
           | Some ctx ->
             List.iter


### PR DESCRIPTION
When a non-linear constraint is solved as an equation in
`matching.ml` we call the `R.constraint_convertibility` function
instead of `R.are_convertible`.