### PR TITLE
dune-project: Fix the license declaration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ env:
   - OCAML_VERSION=4.07.1
   - OCAML_VERSION=4.08.1
   - OCAML_VERSION=4.09.0
+  - OCAML_VERSION=4.10.0
+  - OCAML_VERSION=4.11.1
 
 before_install:
   # Obtain and install opam locally.
@@ -45,7 +47,7 @@ install:
 
 script:
   - make tests
-  - if [[ "$OCAML_VERSION" == "4.09.0" ]];
+  - if [[ "$OCAML_VERSION" == "4.11.1" ]];
       then
         if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]];
           then make full_tests;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
   - OPAMYES="true"
   - OPAMVERBOSE="true"
   matrix:
-  - OCAML_VERSION=4.04.2
-  - OCAML_VERSION=4.05.0
   - OCAML_VERSION=4.06.0
   - OCAML_VERSION=4.06.0+flambda
   - OCAML_VERSION=4.06.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ USER MANUAL FOR DEDUKTI (DEVELOPMENT VERSION)
 ### INSTALLATION
 
 To compile (and optionally install) `Dedukti` you will need:
- - `OCaml >= 4.04`,
+ - `OCaml >= 4.06`,
  - `Menhir`,
  - `dune`,
  - `odoc` (doc only).

--- a/dune-project
+++ b/dune-project
@@ -4,7 +4,7 @@
 
 (generate_opam_files true)
 
-(license MIT)
+(license CECILL-B)
 (maintainers "dedukti-dev@inria.fr")
 (authors "dedukti-dev@inria.fr")
 (source (github Deducteam/Dedukti))

--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,7 @@
 (package
     (name dedukti)
     (depends
-      (ocaml (>= 4.04))
+      (ocaml (>= 4.06))
       menhir)
     (synopsis "An implementation of The Lambda-Pi Modulo Theory")
     (description "An implementation of The Lambda-Pi Modulo Theory"))


### PR DESCRIPTION
Dedukti is released under the CeCILL-B license (as said in the README
and the LICENSE file). This commit fixes the license declaration in
the dune-project file so that the generated dedukti.opam file declares
the correct license.