### PR TITLE
cmdliner for dkcheck

### DIFF
--- a/commands/dkmeta.ml
+++ b/commands/dkmeta.ml
@@ -80,7 +80,7 @@ let _ =
         ( "--no-beta",
           Arg.Unit switch_beta_off,
           " switch off beta while normalizing terms" );
-        ("-nc", Arg.Clear Errors.color, "");
+        ("--no-color", Arg.Clear Errors.color, "");
         ( "-stdin",
           Arg.String (fun n -> run_on_stdin := Some n),
           " MOD Parses standard input using module name MOD" );

--- a/commands/dune
+++ b/commands/dune
@@ -3,7 +3,7 @@
  (public_name dkcheck)
  (modules dkcheck)
  (package dedukti)
- (libraries kernel parsers api))
+ (libraries cmdliner kernel parsers api))
 
 (executable
  (name dkdep)

--- a/tests/dedukti.ml
+++ b/tests/dedukti.ml
@@ -16,8 +16,8 @@ let run ~regression ~error ~title ~tags ~filename command arguments =
   in
   register (fun () ->
       let output_options =
-        (* -nc: Do not print color characters in regression output. *)
-        if regression <> None then ["-nc"; "-q"]
+        (* --no-color: Do not print color characters in regression output. *)
+        if regression <> None then ["--no-color"; "-q"]
         else if Cli.options.log_level = Cli.Report then ["-q"]
         else if Cli.options.log_level = Cli.Debug then ["-d"; "montru"]
         else if Cli.options.log_level = Cli.Info then ["-d"; "n"]

--- a/tests/scripts/KO.sh
+++ b/tests/scripts/KO.sh
@@ -6,4 +6,4 @@ shift #Remove the filename (which is duplicated anyway)
 err_code=$1
 shift
 
-./dkcheck.native -nc $@ 2>&1 | grep -i -q "^\[ERROR CODE:$err_code\]"
+./dkcheck.native --no-color $@ 2>&1 | grep -i -q "^\[ERROR CODE:$err_code\]"

--- a/tests/scripts/OK.sh
+++ b/tests/scripts/OK.sh
@@ -3,7 +3,7 @@
 shift #Remove the reset regression parameter
 shift #Remove the filename (which is duplicated anyway)
 
-OUT=$(./dkcheck.native -nc $@ 2>&1 | uniq -c | egrep "^ *[0-9]*(1|3|5|7|9) .*")
+OUT=$(./dkcheck.native --no-color $@ 2>&1 | uniq -c | egrep "^ *[0-9]*(1|3|5|7|9) .*")
 LINES=$(echo $OUT | wc -l)
 SUCCESSLINES=$(echo $OUT | grep "^ *1 \[SUCCESS\].*" | wc -l)
 

--- a/tests/tezt/_regressions/tests/OK/nsteps3.dk_dkcheck_ok.out
+++ b/tests/tezt/_regressions/tests/OK/nsteps3.dk_dkcheck_ok.out
@@ -1,6 +1,6 @@
 tests/tezt/_regressions/tests/OK/nsteps3.dk_dkcheck_ok.out
 
-./dkcheck.native -nc -q tests/OK/nsteps3.dk
+./dkcheck.native --no-color -q tests/OK/nsteps3.dk
 plus 2 3
 plus 1 (S (S 2))
 plus 0 (S (S (S 2)))

--- a/tests/tezt/_regressions/tests/meta/simple.dk_dkmeta.out
+++ b/tests/tezt/_regressions/tests/meta/simple.dk_dkmeta.out
@@ -1,6 +1,6 @@
 tests/tezt/_regressions/tests/meta/simple.dk_dkmeta.out
 
-./dkmeta.native -nc -q tests/meta/simple.dk
+./dkmeta.native --no-color -q tests/meta/simple.dk
 nat : Type.
 
 0 : nat.

--- a/tests/tezt/_regressions/tests/meta/simple.dk_dkmeta_no_meta.out
+++ b/tests/tezt/_regressions/tests/meta/simple.dk_dkmeta_no_meta.out
@@ -1,6 +1,6 @@
 tests/tezt/_regressions/tests/meta/simple.dk_dkmeta_no_meta.out
 
-./dkmeta.native -nc -q --no-meta tests/meta/simple.dk
+./dkmeta.native --no-color -q --no-meta tests/meta/simple.dk
 nat : Type.
 
 0 : nat.


### PR DESCRIPTION
Use [cmdliner](https://erratique.ch/software/cmdliner/doc/Cmdliner) to provide a unique command for all tools

Todo:
- [x] curate documentation and manpage for `dkcheck`

**Warning:** the option `-nc` is no longer available. It is replaced by `--nc` or `--no-colors`