### PR TITLE
Fixing the commands to compile libraries and add Cron job to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: ${{ runner.os }}-ocaml-${{ matrix.ocaml-version }}
+          key: |
+            ${{ runner.os }}-ocaml-${{ matrix.ocaml-version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ocaml-${{ matrix.ocaml-version }}-
       - name: setting up opam...
         uses: avsm/setup-ocaml@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
 jobs:
   build:
     strategy:
@@ -30,7 +32,7 @@ jobs:
           opam install ocamlformat
           opam install tezt --no-checksums --keep-build-dir
           opam install ~/.opam/4.13.1/.opam-switch/sources/tezt.1.0.0/tezt/lib
-          opam install z3          
+          opam install z3
       - name: Checking formatting...
         run: |
           eval $(opam env)
@@ -47,3 +49,13 @@ jobs:
         run: |
           eval $(opam env)
           make tezt
+      - name: running light libraries...
+        if: github.event_name != 'schedule'
+        run: |
+          eval $(opam env)
+          make light_tests
+      - name: running all libraries...
+        if: github.event_name == 'schedule'
+        run: |
+          eval $(opam env)
+          make full_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           opam upgrade
           opam pin add -n -k path dedukti .
           opam install --deps-only -d -t dedukti
-          opam install ocamlformat
+          opam install ocamlformat.0.19.0
           opam install tezt --no-checksums --keep-build-dir
           opam install ~/.opam/4.13.1/.opam-switch/sources/tezt.1.0.0/tezt/lib
           opam install z3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
     types: [opened, synchronize, edited, reopened]
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 10 12 * *'
 jobs:
   build:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
     types: [opened, synchronize, edited, reopened]
   workflow_dispatch:
   schedule:
-    - cron: '0 10 12 * *'
+    - cron: '0 0 15 * *'
 jobs:
   build:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ zenon_modulo: all
 
 
 .PHONY: light_tests
-light_tests: all matita-light dklib holide
+light_tests: all matita-light dklib focalide
 
 .PHONY: full_tests
-full_tests: light_tests iprover focalide dedukti-libraries verine # zenon_modulo
+full_tests: all dklib focalide matita iprover holide dedukti-libraries verine # zenon_modulo
 
 .PHONY: cleanlibs
 cleanlibs:

--- a/libraries/dedukti-libraries.sh
+++ b/libraries/dedukti-libraries.sh
@@ -2,7 +2,7 @@
 
 DKCHECK="$(pwd)/../dkcheck.native"
 DKDEP="$(pwd)/../dkdep.native"
-DKFLAGS="-q"
+DKFLAGS=""
 
 SRC="https://github.com/Deducteam/Libraries/archive/master.zip"
 DIR="Libraries-master"

--- a/libraries/dklib.sh
+++ b/libraries/dklib.sh
@@ -44,6 +44,10 @@ if [[ ! -d ${DIR} ]]; then
   # Cleaning up.
   echo -n "  - cleaning up...      "
   rm ${DIR}/.gitignore ${DIR}/README.org
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
+  sed -i 's/-coc/--coc/g' $DIR/Makefile
+  sed -i 's/-cc/--confluence/g' $DIR/Makefile
   echo "OK"
 
   # All done.

--- a/libraries/focalide.sh
+++ b/libraries/focalide.sh
@@ -43,6 +43,11 @@ if [[ ! -d ${DIR} ]]; then
   # Applying the changes (add "#REQUIRE" and create "focalide.dk").
   echo -n "  - applying changes... "
   mv ${DIR}/modulogic.dk ${DIR}/zen.dk
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
+  sed -i 's/-errors/--errors/g' $DIR/Makefile
+  # The command to evaluate changed
+  sed -i 's/#SNF/#EVAL/g' $DIR/*.dk
   echo "OK"
 
   # All done.

--- a/libraries/holide.sh
+++ b/libraries/holide.sh
@@ -46,6 +46,9 @@ if [[ ! -d ${DIR} ]]; then
       sed -i 's/^[{]\([a-zA-Z0-9_-]*\)[}]/thm \1/g' ${FILE}
     fi
   done
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
+  sed -i 's/-error/--error/g' $DIR/Makefile
   echo "OK"
 
   # All done.

--- a/libraries/iprover.sh
+++ b/libraries/iprover.sh
@@ -40,6 +40,13 @@ if [[ ! -d ${DIR} ]]; then
   echo -n "  - extracting...       "
   tar xf iprover.tar.gz
   mv iProverModulo_dk ${DIR}
+  # Escaping the injective function, since it became a keyword since last update of the generator.
+  sed -i 's/\([ \.]\)injective\([ \.]\)/\1{|injective|}\2/g' $DIR/*.dk
+  sed -i 's/\([ \.]\)injective$/\1{|injective|}/g' $DIR/*.dk
+  sed -i 's/^injective\([ \.\n]\)/{|injective|}\1/g' $DIR/*.dk
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
+  sed -i 's/-errors/--errors/g' $DIR/Makefile
   echo "OK"
 
   # All done.

--- a/libraries/matita-light.sh
+++ b/libraries/matita-light.sh
@@ -42,6 +42,10 @@ if [[ ! -d ${DIR} ]]; then
   sed -i '30816,33252d'                      $DIR/matita_arithmetics_factorial.dk
   sed -i '30815s/.*/\./'                     $DIR/matita_arithmetics_factorial.dk
   sed -i 's/def le_fact_10 :/le_fact_10 :/'  $DIR/matita_arithmetics_factorial.dk
+  # Escaping the injective function, since it became a keyword since last update of the generator.
+  sed -i 's/\([ \.]\)injective\([ \.\n]\)/\1{|injective|}\2/g' $DIR/*.dk
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
   echo "OK"
 fi
 

--- a/libraries/matita.sh
+++ b/libraries/matita.sh
@@ -37,6 +37,10 @@ if [[ ! -d ${DIR} ]]; then
   # Extracting the source files.
   echo -n "  - extracting...       "
   tar xf matita.tar.gz
+  # Escaping the injective function, since it became a keyword since last update of the generator.
+  sed -i 's/\([ \.]\)injective\([ \.\n]\)/\1{|injective|}\2/g' $DIR/*.dk
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
   echo "OK"
 fi
 

--- a/libraries/verine.sh
+++ b/libraries/verine.sh
@@ -37,6 +37,9 @@ if [[ ! -d ${DIR} ]]; then
   # Extracting the source files.
   echo -n "  - extracting...       "
   tar xf verine.tar.gz
+  # The options given to dkcheck also changed
+  sed -i 's/-nl//g' $DIR/Makefile
+  sed -i 's/-errors/--errors/g' $DIR/Makefile
   echo "OK"
 
   # All done.

--- a/libraries/zenon_modulo.sh
+++ b/libraries/zenon_modulo.sh
@@ -6,6 +6,7 @@ DKCHECK="$(pwd)/../dkcheck.native"
 DKDEP="$(pwd)/../dkdep.native"
 DKFLAGS="-q"
 
+# This source file is not valid anymore
 SRC="http://deducteam.gforge.inria.fr/lib/zenon_modulo.tar"
 DIR="zenon_modulo"
 


### PR DESCRIPTION
This pull request tries to get back some CI running on the libraries.
I am not familiar with `nubo` yet, but it is probably better to use it rather than get old archives and sedding them to update the syntax.
By the time, I think that checking libraries remains useful.