### PR TITLE
Fix LRA and inconsistent capitalization

### DIFF
--- a/kernel/signature.ml
+++ b/kernel/signature.ml
@@ -370,7 +370,9 @@ let get_env sg lc cst =
 
 let get_infos sg lc cst =
   try HId.find (get_env sg lc cst) (id cst)
-  with Not_found -> raise (Signature_error (SymbolNotFound (lc, cst)))
+  with Not_found -> 
+  Format.eprintf "can't find %a\n%!" pp_name cst;
+  raise (Signature_error (SymbolNotFound (lc, cst)))
 
 let is_injective sg lc cst =
   match (get_infos sg lc cst).stat with

--- a/kernel/typing.ml
+++ b/kernel/typing.ml
@@ -129,6 +129,9 @@ module Make (R : Reduction.S) : S = struct
             pp_term ty_exp);
         if not (SR.convertible sg c d ty_inf ty_exp) then
           let ty_exp' = rename_vars_with_typed_context ctx ty_exp in
+          Format.eprintf 
+            "Error while checking:\n\nctx:   %a\n\nte:  %a\n\nty_exp:  %a\n\nty_inf:  %a\n\n\n" 
+              pp_typed_context ctx pp_term te pp_term ty_exp pp_term ty_inf;
           raise (Typing_error (ConvertibilityError (te, ctx, ty_exp', ty_inf)))
 
   and check_app sg (c : SR.lhs_typing_cstr) (d : int) (ctx : typed_context)

--- a/universo/commands/universo.ml
+++ b/universo/commands/universo.ml
@@ -195,7 +195,7 @@ module Cmd = struct
       match r.pat with
       | R.Pattern (_, _, l) -> (List.map to_string l, r.rhs)
       | _                   -> assert false
-    with _ -> raise @@ Cmd_error (Misc "Wrong solver specification : ")
+    with _ -> raise @@ Cmd_error (Misc "Wrong solver specification")
 
   let mk_lra_reification : unit -> (module L.LRA_REIFICATION) =
    fun () ->

--- a/universo/commands/universo.ml
+++ b/universo/commands/universo.ml
@@ -172,7 +172,8 @@ module Cmd = struct
   let mk_smt_theory : unit -> int -> O.theory =
    fun () ->
     try
-      let meta_rules = Hashtbl.find config "qfuf_specification" in
+      (* FIXME : dynamically change to use LRA specification *)
+      let meta_rules = Hashtbl.find config "lra_specification" in
       let meta = output_meta_cfg () in
       M.add_rules meta meta_rules;
       O.mk_theory meta
@@ -192,19 +193,20 @@ module Cmd = struct
         | R.Var (_, id, _, _) -> B.string_of_ident id
         | _                   -> assert false
       in
+      let _ = Format.printf "r.pat = %a\n" R.pp_pattern r.pat in
       match r.pat with
       | R.Pattern (_, _, l) -> (List.map to_string l, r.rhs)
       | _                   -> assert false
-    with _ -> raise @@ Cmd_error (Misc "Wrong solver specification")
+    with _ -> raise @@ Cmd_error (Misc ("Wrong solver specification : "^s))
 
   let mk_lra_reification : unit -> (module L.LRA_REIFICATION) =
    fun () ->
     (module struct
-      let axiom_specification = get_lra_specification_config "axiom"
+      let axiom_specification = get_lra_specification_config "Axiom"
 
-      let rule_specification = get_lra_specification_config "rule"
+      let rule_specification = get_lra_specification_config "Rule"
 
-      let cumul_specification = get_lra_specification_config "cumul"
+      let cumul_specification = get_lra_specification_config "Cumul"
     end)
 
   let mk_solver : unit -> (module Solving.Utils.SOLVER) * Solving.Utils.env =

--- a/universo/commands/universo.ml
+++ b/universo/commands/universo.ml
@@ -169,11 +169,10 @@ module Cmd = struct
     {env; in_path; meta_out = output_meta_cfg (); constraints; out_file}
 
   (** [theory_meta f] returns the meta configuration that allows to elaborate a theory for the SMT solver *)
-  let mk_smt_theory : unit -> int -> O.theory =
-   fun () ->
+  let mk_smt_theory : string -> unit -> int -> O.theory =
+   fun spec () ->
     try
-      (* FIXME : dynamically change to use LRA or QFUF specification *)
-      let meta_rules = Hashtbl.find config "lra_specification" in
+      let meta_rules = Hashtbl.find config spec in
       let meta = output_meta_cfg () in
       M.add_rules meta meta_rules;
       O.mk_theory meta
@@ -249,7 +248,8 @@ module Cmd = struct
     let min = int_of_string (find "minimum" "1") in
     let max = int_of_string (find "maximum" "6") in
     let print = find "print" "false" = "true" in
-    let mk_theory = mk_smt_theory () in
+    let spec = logic ^ "_specification" in
+    let mk_theory = mk_smt_theory spec () in
     let env = {min; max; print; mk_theory} in
     ((module S : Utils.SOLVER), env)
 end

--- a/universo/commands/universo.ml
+++ b/universo/commands/universo.ml
@@ -193,7 +193,6 @@ module Cmd = struct
         | R.Var (_, id, _, _) -> B.string_of_ident id
         | _                   -> assert false
       in
-      let _ = Format.printf "r.pat = %a\n" R.pp_pattern r.pat in
       match r.pat with
       | R.Pattern (_, _, l) -> (List.map to_string l, r.rhs)
       | _                   -> assert false

--- a/universo/commands/universo.ml
+++ b/universo/commands/universo.ml
@@ -172,7 +172,7 @@ module Cmd = struct
   let mk_smt_theory : unit -> int -> O.theory =
    fun () ->
     try
-      (* FIXME : dynamically change to use LRA specification *)
+      (* FIXME : dynamically change to use LRA or QFUF specification *)
       let meta_rules = Hashtbl.find config "lra_specification" in
       let meta = output_meta_cfg () in
       M.add_rules meta meta_rules;
@@ -196,7 +196,7 @@ module Cmd = struct
       match r.pat with
       | R.Pattern (_, _, l) -> (List.map to_string l, r.rhs)
       | _                   -> assert false
-    with _ -> raise @@ Cmd_error (Misc ("Wrong solver specification : "^s))
+    with _ -> raise @@ Cmd_error (Misc "Wrong solver specification : ")
 
   let mk_lra_reification : unit -> (module L.LRA_REIFICATION) =
    fun () ->

--- a/universo/solving/z3arith.ml
+++ b/universo/solving/z3arith.ml
@@ -74,8 +74,7 @@ module Make (Spec : L.LRA_SPECIFICATION) = struct
    fun ctx _ model var ->
     match Z3.Model.get_const_interp_e model (mk_var ctx var) with
     | None   ->
-        Format.eprintf "%s@." var;
-        assert false
+        U.Enum 0 (* The Variable probably doesn't have any constraints on it *)
     | Some e ->
         let v = Z.to_int (ZI.get_big_int e) in
         U.Enum v


### PR DESCRIPTION
This fixes the following two issues with LRA specification
- There is an inconsistency in capitalizations: qfuf specifications require `Axiom`,`Rule` etc. and lra specification require `axiom`, `rule` etc.
- After fixing 1 using [this](https://github.com/firewall2142/Dedukti/compare/c65e7e6..0c96118) (but only changing `axiom` to `Axiom`, `rule` to `Rule` etc.). I am not able to use LRA specification. [The QFUF branch](https://github.com/firewall2142/universo-translator/tree/universo_issue_test) branch works but [the LRA branch](https://github.com/firewall2142/universo-translator/tree/universo_issue_test2) doesn't
To make the LRA branch work I need to [change `qfuf_specification` to `lra_specification`](https://github.com/firewall2142/Dedukti/compare/c65e7e6..0c96118) but this breaks the QFUF branch.