### PR TITLE
Kernel: Optimise conversion

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -504,8 +504,12 @@ module Make (C : ConvChecker) (M : Matching.Matcher) : S = struct
   let rec are_convertible_lst sg : (term * term) list -> bool = function
     | [] -> true
     | (t1, t2) :: lst ->
+        (* Check physical equality first for optimisation. *)
         are_convertible_lst sg
-          (if term_eq t1 t2 then lst
+          (if t1 == t2 then lst
+           (* This test can be less expensive than computing the `whnf` if the
+              two terms are equal. *)
+          else if term_eq t1 t2 then lst
           else conversion_step sg (whnf sg t1, whnf sg t2) lst)
 
   (* Convertibility Test *)


### PR DESCRIPTION
Partial answer to #279 .

1. We add a physical equality for optimisation. We can check this may be triggered by some unit tests
2. We still keep the syntactic equality. This is to avoid to compute the WHNF while to terms are syntactically equal (see test : `tests/OK/sharing.dk`).
