### PR TITLE
Miscellaneous fixes

### DIFF
--- a/dedukti.opam
+++ b/dedukti.opam
@@ -8,14 +8,15 @@ license: "CECILL-B"
 homepage: "https://github.com/Deducteam/Dedukti"
 bug-reports: "https://github.com/Deducteam/Dedukti/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "cmdliner" {>= "1.1.0"}
   "tezt" {with-test & >= "2.0"}
   "menhir" {>= "20180528"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.7)
 (name dedukti)
 (using menhir 2.0)
 
@@ -25,6 +25,6 @@
 	(description "A tool for Dedukti to play with universes")
         (depends
           (ocaml (>= 4.08))
-          (dedukti (>= version))
-          z3
+          (dedukti (>= 2.7))
+          (z3 (>= 4.8.11))
           (tezt (and :with-test (>= 2.0)))))

--- a/universo.opam
+++ b/universo.opam
@@ -8,14 +8,15 @@ license: "CECILL-B"
 homepage: "https://github.com/Deducteam/Dedukti"
 bug-reports: "https://github.com/Deducteam/Dedukti/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "dedukti" {>= "version"}
-  "z3"
+  "dedukti" {>= "2.7"}
+  "z3" {>= "4.8.11"}
   "tezt" {with-test & >= "2.0"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
- universo depends on dedukti >= 2.7
- It is advised to use dune >= 2.7 to generate opam files (see linter
  of opam ci)
- z3 >= 4.8.11 (a lower bound may exist)