### PR TITLE
Importation is not before type checking

### DIFF
--- a/api/dep.mli
+++ b/api/dep.mli
@@ -47,7 +47,7 @@ val compute_all_deps : bool ref
 val get_data : Basic.name -> data
 
 (** [make md es] computes dependencies for the entries [es] in module [md] *)
-val make : Basic.mident -> Entry.entry list -> unit
+val make : ?filename:string -> Basic.mident -> Entry.entry list -> unit
 
 (** [handle md f] computes dependencies on the fly for the entries in module [md] *)
 val handle : Basic.mident -> ((Entry.entry -> unit) -> unit) -> unit

--- a/api/env.ml
+++ b/api/env.ml
@@ -28,7 +28,7 @@ type t = {
 }
 
 let dummy ?(md = Basic.mk_mident "") () =
-  let dummy_sig = Signature.make md (fun _ _ -> "") in
+  let dummy_sig = Signature.make md in
   {
     input = Parser.input_from_string md "";
     sg = dummy_sig;
@@ -45,7 +45,7 @@ let check_arity = ref true
 let check_ll = ref false
 
 let init input =
-  let sg = Signature.make (Parser.md_of_input input) Files.find_object_file in
+  let sg = Signature.make (Parser.md_of_input input) in
   let red : (module Reduction.S) = (module Reduction.Default) in
   let typer : (module Typing.S) = (module Typing.Default) in
   {input; sg; red; typer}
@@ -203,3 +203,5 @@ let fail_env_error : t -> Basic.loc -> exn -> 'a =
   let file = get_filename env in
   let code, lc, msg = Errors.string_of_exception ~red:(snf env) lc exn in
   Errors.fail_exit ~file ~code:(string_of_int code) (Some lc) "%s" msg
+
+let mem {sg; _} md = Signature.mem sg md

--- a/api/env.mli
+++ b/api/env.mli
@@ -93,8 +93,11 @@ val get_dtree : t -> loc -> name -> Dtree.t
 (** [export env] saves the current environment in a [*.dko] file. *)
 val export : t -> unit
 
-(** [import env lc md] the module [md] in the current environment. *)
-val import : t -> loc -> mident -> unit
+(** [import env lc md filename] imports [filename] as module [md] in
+   the current environment. *)
+val import : t -> loc -> mident -> string -> mident list
+
+val mem : t -> mident -> bool
 
 (** [declare_constant env l id st ty] declares the symbol [id] of type [ty] and
     staticity [st]. *)

--- a/api/meta.ml
+++ b/api/meta.ml
@@ -48,7 +48,7 @@ let signature_add_rules sg rs = List.iter (signature_add_rule sg) rs
 let default_config ?meta_rules ?(beta = true) ?encoding ?(decoding = true)
     ?(register_before = true) () =
   let meta_mident = Basic.mk_mident "<meta>" in
-  let meta_signature = Signature.make meta_mident Files.find_object_file in
+  let meta_signature = Signature.make meta_mident in
   Option.iter
     (fun (module E : ENCODING) ->
       Signature.import_signature meta_signature E.signature)
@@ -112,7 +112,7 @@ module PROD = struct
     List.map mk_decl ["ty"; "prod"]
 
   let signature =
-    let sg = Signature.make md Files.find_object_file in
+    let sg = Signature.make md in
     let mk_decl id =
       Signature.add_declaration sg dloc (mk_ident id) Signature.Public
         (Signature.Definable Free) (mk_Type dloc)
@@ -214,7 +214,7 @@ module LF = struct
     List.map mk_decl ["ty"; "var"; "sym"; "lam"; "app"; "prod"]
 
   let signature =
-    let sg = Signature.make md Files.find_object_file in
+    let sg = Signature.make md in
     let mk_decl id =
       Signature.add_declaration sg dloc (mk_ident id) Signature.Public
         (Signature.Definable Free) (mk_Type dloc)
@@ -346,7 +346,7 @@ module APP = struct
     List.map mk_decl ["ty"; "var"; "sym"; "lam"; "app"; "prod"]
 
   let signature =
-    let sg = Signature.make md Files.find_object_file in
+    let sg = Signature.make md in
     let mk_decl id =
       Signature.add_declaration sg dloc (mk_ident id) Signature.Public
         (Signature.Definable Free) (mk_Type dloc)
@@ -443,7 +443,7 @@ module APP = struct
       rhs = encode_term sg r''.ctx r.rhs;
     }
 
-  let fake_sig () = Signature.make (Basic.mk_mident "") Files.find_object_file
+  let fake_sig () = Signature.make (Basic.mk_mident "")
 
   let encode_term ?(sg = fake_sig ()) ?(ctx = []) t = encode_term sg ctx t
 

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -49,8 +49,8 @@ type scope =
 (** A collection of well-typed symbols and rewrite rules. *)
 type t
 
-(** [make file] creates a new signature corresponding to the file [file]. *)
-val make : mident -> (loc -> mident -> file) -> t
+(** [make name] creates a new signature under the name [name]. *)
+val make : mident -> t
 
 (** [get_name sg] returns the name of the signature [sg]. *)
 val get_name : t -> mident
@@ -86,8 +86,10 @@ val get_neutral : t -> loc -> name -> term
 (** [is_AC sg l na] returns true when [na] is declared as AC symbol *)
 val is_AC : t -> loc -> name -> bool
 
-(** [import sg md] the module [md] in the signature [sg]. *)
-val import : t -> loc -> mident -> unit
+(** [import sg md filename] the module [filename] as [md] in the signature [sg]. *)
+val import : t -> loc -> mident -> string -> mident list
+
+val mem : t -> mident -> bool
 
 (** [get_dtree sg filter l cst] returns the decision/matching tree associated
     with [cst] inside the environment [sg]. *)

--- a/kernel/signature.mli
+++ b/kernel/signature.mli
@@ -60,11 +60,6 @@ val export : t -> out_channel -> unit
 
 val get_id_comparator : t -> name comparator
 
-(*
-val import              : t -> loc -> mident -> unit
-(** [import sg md] impots the module [md] in the signature [sg]. *)
-*)
-
 (** [import sg sg_ext] imports the signature [sg_ext] into the signature [sg]. *)
 val import_signature : t -> t -> unit
 

--- a/tests/KO/scoping_ext.dk
+++ b/tests/KO/scoping_ext.dk
@@ -1,3 +1,3 @@
-(; KO 902 ;)
+(; KO 306 ;)
 
 id:toto.tata.

--- a/tests/scripts/OK.sh
+++ b/tests/scripts/OK.sh
@@ -14,6 +14,7 @@ if [ $LINES -eq 1 ] && [ $SUCCESSLINES -eq 1 ]
 then
 	exit 0
 else
+    echo $OUT    
     exit 1
 fi
 


### PR DESCRIPTION
The current mechanism to import dependencies is done at runtime while type checking a term. Dependencies are imported on the fly.

This side-effect is convenient for prototyping, but has disadvantages. The main one being that the type checking and reduction produce both side-effects on the signature. 

This raises several issues when Dedukti is used as a library via the modules in `api` folder.

To overcome this, a way is to always ensure that modules are imported before type checking. This PR is a first step towards this goal:

1. We ensure modules are imported before starting to type check them
2. We keep the importation to be explicit. We could argue later on that the `REQUIRE` directive should be mandatory but I suspect this is a choice which will impact the standardisation of Dedukti so we make no commitment on it.

Performance-wise, this MR has one main downside which is terms processed twice instead of one. I suspect this is not sensible since in practice we spend most of our time doing reductions. However, this could be avoided if we solve 2.

TODO:

- [ ] Clean up the code
- [ ]  Add more tests
- [ ] Add an option like `--no-implicit-import` to get the benefit of 2. without the downside of computing the dependencies. If a dependency is missing, the type checking will simply fail.