### PR TITLE
Rules: Allow type annotations in higher-order patterns

### DIFF
--- a/api/dep.ml
+++ b/api/dep.ml
@@ -62,7 +62,7 @@ let rec mk_pattern p =
   | Pattern (_, c, args) ->
       List.fold_left (fun deps args -> merge deps (mk_pattern args)) empty args
       |> merge (mk_name c)
-  | Lambda (_, _, te) -> mk_pattern te
+  | Lambda (_, _, _, te) -> mk_pattern te
   | Brackets t -> mk_term t
 
 let mk_rule r =

--- a/api/dep_legacy.ml
+++ b/api/dep_legacy.ml
@@ -128,7 +128,7 @@ let rec mk_pattern p =
   match p with
   | Var (_, _, _, args) -> List.iter mk_pattern args
   | Pattern (_, c, args) -> mk_name c; List.iter mk_pattern args
-  | Lambda (_, _, te) -> mk_pattern te
+  | Lambda (_, _, _, te) -> mk_pattern te
   | Brackets t -> mk_term t
 
 let mk_rule r =

--- a/api/meta.ml
+++ b/api/meta.ml
@@ -274,8 +274,8 @@ module LF = struct
     match pattern with
     | Var (lc, id, n, ps) -> Var (lc, id, n, List.map encode_pattern ps)
     | Brackets term -> Brackets (encode_term term)
-    | Lambda (lc, id, p) ->
-        Pattern (lc, name_of "lam", [Lambda (lc, id, encode_pattern p)])
+    | Lambda (lc, id, ty_opt, p) ->
+        Pattern (lc, name_of "lam", [Lambda (lc, id, ty_opt, encode_pattern p)])
     | Pattern (lc, n, []) -> Pattern (lc, name_of "sym", [Pattern (lc, n, [])])
     | Pattern (lc, n, ps) ->
         Pattern
@@ -420,9 +420,11 @@ module APP = struct
     match pattern with
     | Var (lc, id, n, ps) -> Var (lc, id, n, List.map (encode_pattern sg ctx) ps)
     | Brackets term -> Brackets (encode_term sg ctx term)
-    | Lambda (lc, id, p) ->
+    | Lambda (lc, id, ty_opt, p) ->
         Pattern
-          (lc, name_of "lam", [dummy; Lambda (lc, id, encode_pattern sg ctx p)])
+          ( lc,
+            name_of "lam",
+            [dummy; Lambda (lc, id, ty_opt, encode_pattern sg ctx p)] )
     | Pattern (lc, n, []) -> Pattern (lc, name_of "sym", [Pattern (lc, n, [])])
     | Pattern (lc, n, [a]) ->
         Pattern
@@ -554,7 +556,7 @@ let rec pattern_of_term t =
   let open Term in
   match t with
   | Kind | Type _ | Pi _ -> raise Not_a_pattern
-  | Lam (lc, x, _, te) -> Rule.Lambda (lc, x, pattern_of_term te)
+  | Lam (lc, x, ty_opt, te) -> Rule.Lambda (lc, x, ty_opt, pattern_of_term te)
   | App (Const (lc, name), a, args) ->
       Rule.Pattern (lc, name, List.map pattern_of_term (a :: args))
   | App (DB (lc, x, n), a, args) ->

--- a/api/pp.ml
+++ b/api/pp.ml
@@ -202,8 +202,11 @@ module Make (S : Sig) : Printer = struct
         fprintf out "%a %a" print_const cst
           (print_list " " print_pattern_wp)
           pats
-    | Lambda (_, x, p) ->
+    | Lambda (_, x, None, p) ->
         fprintf out "@[%a => %a@]" print_ident x print_pattern p
+    | Lambda (_, x, Some ty, p) ->
+        fprintf out "@[%a : %a => %a@]" print_ident x print_term ty
+          print_pattern p
 
   and print_pattern_wp out = function
     | (Pattern _ | Lambda _) as p -> fprintf out "(%a)" print_pattern p

--- a/kernel/confluence.ml
+++ b/kernel/confluence.ml
@@ -87,7 +87,7 @@ let pp_pattern ar fmt pat =
           List.iter (fprintf fmt ",%a" (aux k)) args1;
           fprintf fmt ")";
           List.iter (fprintf fmt ",%a)" (aux k)) args2
-    | Lambda (_, x, p) ->
+    | Lambda (_, x, _, p) ->
         fprintf fmt "lam(m_typ,\\v_%a.%a)" pp_ident x (aux (k + 1)) p
     | Brackets _ -> incr nb; fprintf fmt "b_%i" !nb
   in
@@ -144,7 +144,7 @@ let get_bvars r =
   let rec aux_p k bvars = function
     | Var (_, _, _, args) | Pattern (_, _, args) ->
         List.fold_left (aux_p k) bvars args
-    | Lambda (_, x, p) -> aux_p (k + 1) (x :: bvars) p
+    | Lambda (_, x, _, p) -> aux_p (k + 1) (x :: bvars) p
     | Brackets te -> aux_t k bvars te
   in
   let bvars0 = aux_p 0 [] pat in
@@ -164,7 +164,7 @@ let get_arities (p : pattern) : int IdMap.t =
           with Not_found -> ar1
         in
         IdMap.add x ar map2
-    | Lambda (_, _, p) -> aux (k + 1) map p
+    | Lambda (_, _, _, p) -> aux (k + 1) map p
     | Brackets _ -> map
   in
   aux 0 IdMap.empty p

--- a/kernel/rule.mli
+++ b/kernel/rule.mli
@@ -9,7 +9,7 @@ open Term
 type pattern =
   | Var of loc * ident * int * pattern list  (** Applied DB variable *)
   | Pattern of loc * name * pattern list  (** Applied constant    *)
-  | Lambda of loc * ident * pattern  (** Lambda abstraction  *)
+  | Lambda of loc * ident * term option * pattern  (** Lambda abstraction  *)
   | Brackets of term  (** Bracket of a term   *)
 
 val get_loc_pat : pattern -> loc

--- a/parsing/menhir_parser.mly
+++ b/parsing/menhir_parser.mly
@@ -221,8 +221,12 @@ pattern_wp:
   | LEFTBRA term RIGHTBRA    { PCondition $2 }
   | LEFTPAR pattern RIGHTPAR { $2 }
 
+of_aty:
+  | COLON te=aterm { te }
+
 pattern:
-  | pid FATARROW pattern     { PLambda (fst $1,snd $1,$3) }
+  | pid=pid ty_opt=ioption(of_aty) FATARROW pattern=pattern
+    { PLambda (fst pid, snd pid, ty_opt, pattern) }
   | pattern_wp+              { PApp($1) }
 
 sterm:

--- a/parsing/preterm.mli
+++ b/parsing/preterm.mli
@@ -23,7 +23,7 @@ val pp_preterm : formatter -> preterm -> unit
 type prepattern =
   | PCondition of preterm
   | PPattern of loc * mident option * ident * prepattern list
-  | PLambda of loc * ident * prepattern
+  | PLambda of loc * ident * preterm option * prepattern
   | PJoker of loc * prepattern list
   | PApp of prepattern list
 

--- a/parsing/scoping.ml
+++ b/parsing/scoping.ml
@@ -74,7 +74,7 @@ let get_vars_order (vars : pcontext) (ppat : prepattern) :
           in
           List.fold_left (aux bvar) new_ctx pargs
     | PPattern (_, Some _, _, pargs) -> List.fold_left (aux bvar) ctx pargs
-    | PLambda (_, x, pp) -> aux (x :: bvar) ctx pp
+    | PLambda (_, x, _, pp) -> aux (x :: bvar) ctx pp
     | PCondition _ ->
         has_brackets := true;
         ctx
@@ -99,7 +99,9 @@ let p_of_pp md (ctx : ident list) (ppat : prepattern) : pattern =
         | None -> Pattern (l, mk_name md id, List.map (aux ctx) pargs))
     | PPattern (l, Some md, id, pargs) ->
         Pattern (l, mk_name md id, List.map (aux ctx) pargs)
-    | PLambda (l, x, pp) -> Lambda (l, x, aux (x :: ctx) pp)
+    | PLambda (l, x, None, pp) -> Lambda (l, x, None, aux (x :: ctx) pp)
+    | PLambda (l, x, Some ty, pp) ->
+        Lambda (l, x, Some (t_of_pt md ctx ty), aux (x :: ctx) pp)
     | PCondition pte -> Brackets (t_of_pt md ctx pte)
     | PJoker (l, pargs) -> (
         let id = get_fresh_name () in

--- a/tests/KO/ho_match.dk
+++ b/tests/KO/ho_match.dk
@@ -1,0 +1,10 @@
+N : Type.
+0 : N.
+
+def f : N -> N.
+[x] f x --> 0.
+
+#ASSERT (y:N => f y) == (y:N => 0).
+
+def g : (N -> N) -> N.
+[h] g (x : (N -> N) => h x) --> 0.

--- a/tests/OK/ho_match.dk
+++ b/tests/OK/ho_match.dk
@@ -13,3 +13,6 @@ def g : (N -> N) -> N.
 #ASSERT ( y:N => g (x => x  ) ) == (y:N => 0).
 #ASSERT ( y:N => g (x => y  ) ) == (y:N => 0).
 #ASSERT ( y:N => g (x => f y) ) == (y:N => 0).
+
+def gg : (N -> N) -> N.
+[h] gg (x : N => h x) --> 0.

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -263,7 +263,8 @@ module Check = struct
       ko ~error:(`Code 101) ~basename:"untypable_lhs.dk" [];
       ko ~error:(`Code 306) ~basename:"pragma.dk" [];
       ko ~error:(`Code 704) ~basename:"opacity.dk" [];
-      ko ~error:(`Code 704) ~basename:"opacity2.dk" []
+      ko ~error:(`Code 704) ~basename:"opacity2.dk" [];
+      ko ~error:(`Code 208) ~basename:"ho_match.dk" []
 
     module Acu = struct
       let ko ~error ~basename =


### PR DESCRIPTION
To make Dedukti compliant with the standard.