### PR TITLE
Fix display of version

### DIFF
--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -136,5 +136,4 @@ let cmd =
       `P "Report bugs to <dedukti-dev@inria.fr>.";
     ]
   in
-  let version = Version.version in
-  Cmd.v (Cmd.info "check" ~version ~doc ~man) cmd_t
+  Cmd.v (Cmd.info "check" ~doc ~man) cmd_t

--- a/commands/dkcheck.ml
+++ b/commands/dkcheck.ml
@@ -136,4 +136,5 @@ let cmd =
       `P "Report bugs to <dedukti-dev@inria.fr>.";
     ]
   in
-  Cmd.v (Cmd.info "check" ~version:"%%VERSION%%" ~doc ~man) cmd_t
+  let version = Version.version in
+  Cmd.v (Cmd.info "check" ~version ~doc ~man) cmd_t

--- a/commands/dkdep.ml
+++ b/commands/dkdep.ml
@@ -103,4 +103,5 @@ let cmd_t = Term.(const dkdep $ Config.t $ ignore $ output $ sort $ files)
 
 let cmd =
   let doc = "Dependency list generator for Dedukti files" in
-  Cmd.(v (info "dep" ~version:"%%VERSION%%" ~doc) cmd_t)
+  let version = Version.version in
+  Cmd.(v (info "dep" ~version ~doc) cmd_t)

--- a/commands/dkdep.ml
+++ b/commands/dkdep.ml
@@ -103,5 +103,4 @@ let cmd_t = Term.(const dkdep $ Config.t $ ignore $ output $ sort $ files)
 
 let cmd =
   let doc = "Dependency list generator for Dedukti files" in
-  let version = Version.version in
-  Cmd.(v (info "dep" ~version ~doc) cmd_t)
+  Cmd.(v (info "dep" ~doc) cmd_t)

--- a/commands/dkmeta.ml
+++ b/commands/dkmeta.ml
@@ -115,5 +115,4 @@ let cmd_t =
 
 let cmd =
   let doc = "Transform dk signatures using dk." in
-  let version = Version.version in
-  Cmdliner.Cmd.(v (info "meta" ~doc ~version) cmd_t)
+  Cmdliner.Cmd.(v (info "meta" ~doc) cmd_t)

--- a/commands/dkmeta.ml
+++ b/commands/dkmeta.ml
@@ -115,4 +115,5 @@ let cmd_t =
 
 let cmd =
   let doc = "Transform dk signatures using dk." in
-  Cmdliner.Cmd.(v (info "meta" ~doc ~version:"%%VERSION%%") cmd_t)
+  let version = Version.version in
+  Cmdliner.Cmd.(v (info "meta" ~doc ~version) cmd_t)

--- a/commands/dkpretty.ml
+++ b/commands/dkpretty.ml
@@ -28,4 +28,5 @@ let cmd_t = Term.(const beautify $ Config.t $ files)
 let cmd =
   let doc = "Pretty print Dedukti files" in
   let man = [] in
-  Cmd.(v (info "beautify" ~version:"%%VERSION%%" ~doc ~man) cmd_t)
+  let version = Version.version in
+  Cmd.(v (info "beautify" ~version ~doc ~man) cmd_t)

--- a/commands/dkpretty.ml
+++ b/commands/dkpretty.ml
@@ -28,5 +28,4 @@ let cmd_t = Term.(const beautify $ Config.t $ files)
 let cmd =
   let doc = "Pretty print Dedukti files" in
   let man = [] in
-  let version = Version.version in
-  Cmd.(v (info "beautify" ~version ~doc ~man) cmd_t)
+  Cmd.(v (info "beautify" ~doc ~man) cmd_t)

--- a/commands/dkprune.ml
+++ b/commands/dkprune.ml
@@ -303,4 +303,5 @@ let cmd_t = Cmdliner.Term.(const prune $ Config.t $ log $ output $ files)
 
 let cmd =
   let doc = "Compute dependencies of a set of Dedukti files." in
-  Cmdliner.Cmd.(v (info "prune" ~version:"%%VERSION%%" ~doc) cmd_t)
+  let version = Version.version in
+  Cmdliner.Cmd.(v (info "prune" ~version ~doc) cmd_t)

--- a/commands/dkprune.ml
+++ b/commands/dkprune.ml
@@ -303,5 +303,4 @@ let cmd_t = Cmdliner.Term.(const prune $ Config.t $ log $ output $ files)
 
 let cmd =
   let doc = "Compute dependencies of a set of Dedukti files." in
-  let version = Version.version in
-  Cmdliner.Cmd.(v (info "prune" ~version ~doc) cmd_t)
+  Cmdliner.Cmd.(v (info "prune" ~doc) cmd_t)

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -13,4 +13,5 @@ let cmd_t = Cmdliner.Term.(const top $ Config.t)
 
 let cmd =
   let doc = "Run a read-eval-print-loop using dk-check." in
-  Cmdliner.Cmd.(v (info "top" ~doc ~version:"%%VERSION%%") cmd_t)
+  let version = Version.version in
+  Cmdliner.Cmd.(v (info "top" ~doc ~version) cmd_t)

--- a/commands/dktop.ml
+++ b/commands/dktop.ml
@@ -13,5 +13,4 @@ let cmd_t = Cmdliner.Term.(const top $ Config.t)
 
 let cmd =
   let doc = "Run a read-eval-print-loop using dk-check." in
-  let version = Version.version in
-  Cmdliner.Cmd.(v (info "top" ~doc ~version) cmd_t)
+  Cmdliner.Cmd.(v (info "top" ~doc) cmd_t)

--- a/commands/dune
+++ b/commands/dune
@@ -1,12 +1,13 @@
-(executable
- (name main)
- (modules main dkcheck dkdep dkpretty dkprune dkmeta dktop config)
- (public_name dk)
- (package dedukti)
- (rule
+(rule
  (targets version.ml)
  (action
   (with-stdout-to version.ml
     (run ocaml -I +unix unix.cma %{dep:../misc/gen_version.ml})))
  (mode fallback))
+
+(executable
+ (name main)
+ (modules main dkcheck dkdep dkpretty dkprune dkmeta dktop config version)
+ (public_name dk)
+ (package dedukti)
  (libraries cmdliner kernel parsers api))

--- a/commands/dune
+++ b/commands/dune
@@ -3,4 +3,10 @@
  (modules main dkcheck dkdep dkpretty dkprune dkmeta dktop config)
  (public_name dk)
  (package dedukti)
+ (rule
+ (targets version.ml)
+ (action
+  (with-stdout-to version.ml
+    (run ocaml -I +unix unix.cma %{dep:../misc/gen_version.ml})))
+ (mode fallback))
  (libraries cmdliner kernel parsers api))

--- a/commands/main.ml
+++ b/commands/main.ml
@@ -13,7 +13,8 @@ let default_i =
          Dedukti language.";
     ]
   in
-  Cmd.info "dkcheck" ~version:"%%VERSION%%" ~doc ~sdocs ~man
+  let version = Version.version in
+  Cmd.info "dk check" ~version ~doc ~sdocs ~man
 
 let cmds =
   [Dkcheck.cmd; Dkdep.cmd; Dkpretty.cmd; Dkprune.cmd; Dkmeta.cmd; Dktop.cmd]

--- a/commands/main.ml
+++ b/commands/main.ml
@@ -14,7 +14,7 @@ let default_i =
     ]
   in
   let version = Version.version in
-  Cmd.info "dk" ~version:"%%VERSION%%" ~doc ~sdocs ~man
+  Cmd.info "dk" ~version ~doc ~sdocs ~man
 
 let cmds =
   [Dkcheck.cmd; Dkdep.cmd; Dkpretty.cmd; Dkprune.cmd; Dkmeta.cmd; Dktop.cmd]

--- a/misc/gen_version.ml
+++ b/misc/gen_version.ml
@@ -1,0 +1,20 @@
+let version =
+  (* Trick to check whether the watermark has been substituted. *)
+  if "%%VERSION%%" <> "%%" ^ "VERSION%%" then "%%VERSION%%" else
+  (* If not, we fallback to git version. *)
+  let cmd = "git describe --dirty --always" in
+  let (oc, ic, ec) = Unix.open_process_full cmd (Unix.environment ()) in
+  let version =
+    try Printf.sprintf "dev-%s" (input_line oc)
+    with End_of_file -> "unknown"
+  in
+  match Unix.close_process_full (oc, ic, ec) with
+  | Unix.WEXITED(0) -> version
+  | _               -> "unknown"
+
+let _ =
+  let line fmt = Format.printf (fmt ^^ "@.") in
+  line "(** Version informations. *)";
+  line "";
+  line "(** [version] gives a version description. *)";
+  line "let version : string = %S" version


### PR DESCRIPTION
This PR fixes the display of Dedukti version (#300) when called in command line (for instance dk --version)