### PR TITLE
ci: add ocaml 5.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: [5.4.1]
+        ocaml-version: [5.5.0]
 #        ocaml-format-version: [0.24.1] # 0.24.1 is incompatible with ocaml 5.2.0
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/old-ocaml.yml
+++ b/.github/workflows/old-ocaml.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: [5.3.0, 5.2.1, 4.14.2]
+        ocaml-version: [5.4.1, 5.3.0, 5.2.1, 4.14.2]
     runs-on: ubuntu-latest
     steps:
       - name: check out

--- a/kernel/matching.ml
+++ b/kernel/matching.ml
@@ -14,7 +14,6 @@ type te = term Lazy.t
 type status = Unsolved | Solved of te | Partly of ac_ident * te list
 
 type matching_problem = {
-  eq_problems : te eq_problem list array;
   ac_problems : te list ac_problem list;
   status : status array;
   arities : int array;
@@ -540,7 +539,6 @@ module Make (R : Reducer) : Matcher = struct
             arities = pb.pm_arity;
             status;
             ac_problems = ac_rearrange ac_pbs;
-            eq_problems = [||];
           }
         in
         (* Rearrange AC problems then solve them *)


### PR DESCRIPTION
+ in kernel/matching.ml, type matching_problem, remove field eq_problems which is unused

CI fails because of https://github.com/Deducteam/Dedukti/issues/346
